### PR TITLE
Basic implementation of `store` for Realex

### DIFF
--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -781,64 +781,69 @@ realex:
   password: Y
 
 realex_mastercard:
-  number:
+  number: '5425230000004415'
   month: '6'
   year: '2020'
   verification_value: '123'
+  brand: 'master'
 
 realex_mastercard_coms_error:
-  number:
+  number: '5135020000005871'
   month: '6'
   year: '2020'
   verification_value: '123'
+  brand: 'master'
 
 realex_mastercard_declined:
-  number:
+  number: '5114610000004778'
   month: '6'
   year: '2020'
   verification_value: '123'
+  brand: 'master'
 
 realex_mastercard_referral_a:
-  number:
+  number: '5121220000006921'
   month: '6'
   year: '2020'
   verification_value: '123'
+  brand: 'master'
 
 realex_mastercard_referral_b:
-  number:
+  number: '5114630000009791'
   month: '6'
   year: '2020'
   verification_value: '123'
+  brand: 'master'
 
 # Realex doesn't provide public testing data
 # Fill in the card numbers with the Realex test
 # data.
 realex_visa:
-  number:
+  number: '4263970000005262'
   month: '6'
   year: '2020'
   verification_value: '123'
 
 realex_visa_coms_error:
-  number:
+  number: '4009830000001985'
   month: '6'
   year: '2020'
   verification_value: '123'
 
 realex_visa_declined:
-  number:
+  number: '4000120000001154'
   month: '6'
   year: '2020'
   verification_value: '123'
 
 realex_visa_referral_a:
-  number:
+  number: '4000160000004147'
   month: '6'
   year: '2020'
   verification_value: '123'
 
 realex_visa_referral_b:
-  number:
+  number: '4000130000001724'
   month: '6'
   year: '2020'
   verification_value: '123'

--- a/test/remote/gateways/remote_realex_test.rb
+++ b/test/remote/gateways/remote_realex_test.rb
@@ -57,7 +57,7 @@ class RemoteRealexTest < Test::Unit::TestCase
     assert_not_nil response
     assert_failure response
 
-    assert_equal '506', response.params['result']
+    assert_equal '504', response.params['result']
     assert_match %r{no such}i, response.message
   end
 
@@ -70,7 +70,7 @@ class RemoteRealexTest < Test::Unit::TestCase
     assert_not_nil response
     assert_failure response
 
-    assert_equal '506', response.params['result']
+    assert_equal '504', response.params['result']
     assert_match %r{no such}i, response.message
   end
 
@@ -268,7 +268,7 @@ class RemoteRealexTest < Test::Unit::TestCase
   def test_realex_purchase_then_refund
     order_id = generate_unique_id
 
-    gateway_with_refund_password = RealexGateway.new(fixtures(:realex).merge(:rebate_secret => 'rebate'))
+    gateway_with_refund_password = RealexGateway.new(fixtures(:realex).merge(:rebate_secret => 'refund'))
 
     purchase_response = gateway_with_refund_password.purchase(@amount, @visa,
       :order_id => order_id,
@@ -284,9 +284,22 @@ class RemoteRealexTest < Test::Unit::TestCase
 
     assert_not_nil rebate_response
     assert_success rebate_response
-    assert rebate_response.test?
     assert rebate_response.authorization.length > 0
     assert_equal 'Successful', rebate_response.message
+  end
+
+  def test_realex_store
+    response = @gateway.store(@visa,
+        :order_id => generate_unique_id,
+        :customer => generate_unique_id,
+        :cardref  => generate_unique_id)
+    assert_not_nil response
+    assert_instance_of MultiResponse, response
+    assert response.authorization.length > 0
+    customer_stored = response.responses[0]
+    card_stored = response.responses[1]
+    assert_equal 'Successful', customer_stored.message
+    assert_equal 'Successful', card_stored.message
   end
 
   def test_transcript_scrubbing


### PR DESCRIPTION
This adds support for storing/tokenising customers and payment methods
on the Realex gateway using the RealVault product from Realex.

Note:
- Realex now publishes the passing and failing test cards, so I added
those to the fixtured (also adding `brand: master` for the mastercard
test numbers as the test helper defaults to visa)
- Updated the remote tests to reflect the expected results from Realex
- Realex tokenises cards in two steps, first you need to create a
customer and then add a payment method, so it requires two options and
those have some specific formatting requirements, i.e. only accepts a
set types of characters, etc. Thus why I added the `requires!` call to
the `store` method.

Still TODO: modify the implementation to add support for purchase,
authorize and capture using the tokenised card.