### PR TITLE
Adding support for PSI

### DIFF
--- a/lib/active_merchant/billing/gateways/payment_solutions.rb
+++ b/lib/active_merchant/billing/gateways/payment_solutions.rb
@@ -1,0 +1,223 @@
+require 'nokogiri'
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class PaymentSolutionsGateway < Gateway
+      include Empty
+      self.test_url = 'https://staging.paymentsolutionsinc.net/Services/Aspca/Payment/PsiWcfService.svc'
+      self.live_url = 'https://client.paymentsolutionsinc.net/Services/Payment/PsiWcfService.svc'
+
+      self.supported_countries = ['US']
+      self.default_currency = 'USD'
+      self.money_format = :dollars
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover]
+
+      self.homepage_url = 'http://paymentsolutionsinc.net/'
+      self.display_name = 'Payment Solutions Inc'
+
+      APPROVED, DECLINED, ERROR, FRAUD_REVIEW = 1, 2, 3, 4
+      SOAP_ACTION_NS = 'http://www.paymentsolutionsinc.net/IPsiService/'
+      SOAP_XMLNS = { xmlns: 'http://www.paymentsolutionsinc.net/' }
+      PSI_NS = {
+        'xmlns:d4p1' => 'http://schemas.datacontract.org/2004/07/PsiService',
+        'xmlns:i' => 'http://www.w3.org/2001/XMLSchema-instance'
+      }
+      ENV_NS = { 'xmlns:s' => 'http://schemas.xmlsoap.org/soap/envelope/' }
+      NS = {
+        'xmlns:xsi'  => 'http://schemas.xmlsoap.org/soap/envelope/',
+        'xmlns:env'  => 'http://schemas.xmlsoap.org/soap/envelope/',
+        'xmlns:ins0' => 'http://schemas.datacontract.org/2004/07/PsiService'
+      }
+      CARD_TYPE_MAP = {
+        :visa => 'Visa',
+        :master => 'MasterCard',
+        :american_express => 'AmericanExpress',
+        :discover => 'Discover'
+      }
+
+      def initialize(options={})
+        requires!(options, :username, :password)
+        super
+      end
+
+      def test_connection(message, options={})
+        request = build_soap_request do |xml|
+          xml.TestConnection(SOAP_XMLNS) do
+            add_message(xml, message)
+          end
+        end
+
+        commit('TestConnection', request)
+      end
+
+      def purchase(money, payment, options={})
+        request = build_soap_request do |xml|
+          xml.SendCreditCardPayment(SOAP_XMLNS) do
+            add_authentication(xml, options)
+            xml.paymentInfo(PSI_NS) do
+              add_amount(xml, money)
+              add_order_id(xml, options)
+              add_credit_card(xml, payment, options)
+              add_customer_data(xml, payment, options)
+              add_payment(xml, options)
+            end
+          end
+        end
+
+        commit('SendCreditCardPayment', request)
+      end
+
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript.
+          gsub(%r((<d4p1:UserName>)[^<]*(</d4p1:UserName>))i, '\1[FILTERED]\2').
+          gsub(%r((<d4p1:Password>)[^<]*(</d4p1:Password>))i, '\1[FILTERED]\2').
+          gsub(%r((<d4p1:CardNo>).+(</d4p1:CardNo>))i, '\1[FILTERED]\2').
+          gsub(%r((<d4p1:Cvv>).+(</d4p1:Cvv>))i, '\1[FILTERED]\2')
+      end
+
+      private
+
+      def add_message(xml, message)
+        xml.message message
+      end
+
+      def add_customer_data(xml, payment, options)
+        xml['d4p1'].Donor do
+          address = options[:billing_address] || options[:address]
+          xml['d4p1'].Address1 address[:address1] if address[:address1]
+          xml['d4p1'].City address[:city] if address[:city]
+          xml['d4p1'].Employer nil
+          xml['d4p1'].FirstName payment.first_name
+          xml['d4p1'].LastName payment.last_name
+          xml['d4p1'].Phone address[:phone] if address[:phone]
+          xml['d4p1'].PostalCode address[:zip] if address[:zip]
+          xml['d4p1'].SendEmail false
+          xml['d4p1'].StateProvince address[:state] if address[:state]
+          xml['d4p1'].Address2 address[:address2] if address[:address2]
+          xml['d4p1'].Country address[:country] if address[:country]
+          xml['d4p1'].Email address[:email] if address[:email]
+        end
+      end
+
+      def add_order_id(xml, options)
+        xml['d4p1'].ClientTransactionId truncate(options[:order_id], 20)
+      end
+
+      def add_amount(xml, money)
+        xml['d4p1'].Amount amount(money)
+      end
+
+      def add_payment(xml, options={})
+        xml['d4p1'].Frequency 'Monthly'
+        xml['d4p1'].PayType 'OneTime'
+        xml['d4p1'].ProcessDateTime Time.current.strftime("%FT%T")
+      end
+
+      def add_credit_card(xml, payment, options={})
+        xml['d4p1'].CreditCard do
+          xml['d4p1'].CardNo payment.number
+          xml['d4p1'].ExpMonth format(payment.month, :two_digits)
+          xml['d4p1'].ExpYear format(payment.year, :four_digits)
+          xml['d4p1'].Cvv payment.verification_value if payment.verification_value.present?
+          xml['d4p1'].Type CARD_TYPE_MAP[card_brand(payment).to_sym]
+        end
+      end
+
+      def parse(body)
+        doc = Nokogiri::XML(body)
+        doc.remove_namespaces!
+
+        response = {}
+
+        response[:response_code] = if(element = doc.at_xpath("//SendCreditCardPaymentResult/ResponseCode"))
+          (empty?(element.content) ? nil : element.content.to_i)
+        end
+
+        response[:response_message] = if(element = doc.at_xpath("//SendCreditCardPaymentResult/ResponseMessage"))
+          (empty?(element.content) ? nil : element.content)
+        end
+
+        response[:transaction_id] = if(element = doc.at_xpath("//SendCreditCardPaymentResult/ClientTransactionId"))
+          (empty?(element.content) ? nil : element.content)
+        end
+
+        response[:authorization_code] = if(element = doc.at_xpath("//SendCreditCardPaymentResult/AuthorizationCode"))
+          (empty?(element.content) ? nil : element.content)
+        end
+
+        response[:approved] = if(element = doc.at_xpath("//SendCreditCardPaymentResult/Approved"))
+          (empty?(element.content) ? false : element.content)
+        end
+
+        response
+      end
+
+      def headers(action)
+        {
+          'Content-Type'    => 'text/xml',
+          'SOAPAction'      => "#{SOAP_ACTION_NS}#{action}",
+          'Accept-Encoding' => 'identity'
+        }
+      end
+
+      def url
+        test? ? test_url : live_url
+      end
+
+      def commit(action, xml, amount=nil)
+        response = parse(ssl_post(url, xml, headers(action)))
+
+        Response.new(
+          success_from(response),
+          message_from(response),
+          response,
+          authorization: authorization_from(response),
+          test: test?
+        )
+      end
+
+      def success_from(response)
+        response[:approved] == 'true' && response[:response_code] == APPROVED
+      end
+
+      def message_from(response)
+        response[:response_message]
+      end
+
+      def authorization_from(response)
+        response[:authorization_code]
+      end
+
+      def build_soap_request
+        builder = Nokogiri::XML::Builder.new(encoding: 'UTF-8') do |xml|
+          xml['s'].Envelope(ENV_NS) do
+
+            xml['s'].Body do
+              yield(xml)
+            end
+          end
+        end
+
+        builder.to_xml
+      end
+
+      def add_authentication(xml, options={})
+        xml.credentials(PSI_NS) do
+          xml['d4p1'].Password @options[:password]
+          xml['d4p1'].SourceIpAddress options[:ip] unless empty?(options[:ip])
+          xml['d4p1'].UserName @options[:username]
+        end
+      end
+
+      def error_code_from(response)
+        unless success_from(response)
+          # TODO: lookup error code for this response
+        end
+      end
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -602,6 +602,10 @@ payment_express:
   login: LOGIN
   password: PASSWORD
 
+payment_solutions:
+  username: USERNAME
+  password: PASSWORD
+
 paymill:
   private_key: a9580be4a7b9d0151a3da88c6c935ce0
   public_key: 57313835619696ac361dc591bc973626

--- a/test/remote/gateways/remote_payment_solutions_test.rb
+++ b/test/remote/gateways/remote_payment_solutions_test.rb
@@ -1,0 +1,74 @@
+require 'test_helper'
+
+class RemotePaymentSolutionsTest < Test::Unit::TestCase
+  def setup
+    @gateway = PaymentSolutionsGateway.new(fixtures(:payment_solutions))
+
+    @amount = 100
+    @declined_amount = 200
+    @credit_card = credit_card('4222222222222')
+    @options = {
+      order_id: SecureRandom.hex(10),
+      billing_address: address({
+        city:     'Hollywood',
+        state:    'CA',
+        zip:      '90210',
+        country:  'USA',}),
+      description: 'Store Purchase'
+    }
+    @declined_options = {
+      billing_address: address({
+        city:     'Hollywood',
+        state:    'CA',
+        zip:      '46282',
+        country:  'USA',}),
+      description: 'Store Purchase'
+    }
+  end
+
+  def test_successful_purchase
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'This transaction has been approved.', response.message
+  end
+
+  def test_successful_purchase_with_more_options
+    more_options = {
+      order_id: '2',
+      ip: "127.0.0.1",
+      email: "joe@example.com"
+    }
+
+    @options.merge!(more_options)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'This transaction has been approved.', response.message
+  end
+
+  def test_failed_purchase
+    response = @gateway.purchase(@declined_amount, @credit_card, @declined_options)
+    assert_failure response
+    assert_equal 'This transaction has been declined.', response.message
+  end
+
+  def test_invalid_login
+    gateway = PaymentSolutionsGateway.new(username: '', password: '')
+
+    response = gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_match %r{Invalid Authentication}, response.message
+  end
+
+  def test_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card.number, transcript)
+    assert_scrubbed(@credit_card.verification_value, transcript)
+    assert_scrubbed(@gateway.options[:password], transcript)
+  end
+
+end

--- a/test/unit/gateways/payment_solutions_test.rb
+++ b/test/unit/gateways/payment_solutions_test.rb
@@ -1,0 +1,140 @@
+require 'test_helper'
+
+class PaymentSolutionsTest < Test::Unit::TestCase
+  def setup
+    @gateway = PaymentSolutionsGateway.new(username: 'login', password: 'password')
+    @credit_card = credit_card
+    @amount = 100
+
+    @options = {
+      order_id: '2',
+      billing_address: address({
+        city:     'Hollywood',
+        state:    'CA',
+        zip:      '90210',
+        country:  'USA',}),
+      description: 'Store Purchase'
+    }
+  end
+
+  def test_successful_purchase
+    @gateway.expects(:ssl_post).returns(successful_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+
+    assert_equal '000000', response.authorization
+    assert response.test?
+  end
+
+  def test_failed_purchase
+    @gateway.expects(:ssl_post).returns(failed_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal 'This transaction has been declined.', response.message
+  end
+
+
+  def test_scrub
+    assert @gateway.supports_scrubbing?
+    assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
+  end
+
+  private
+
+  def pre_scrubbed
+    <<-eos
+      opening connection to staging.paymentsolutionsinc.net:443...
+      opened
+      starting SSL for staging.paymentsolutionsinc.net:443...
+      SSL established
+      <- "POST /Services/Aspca/Payment/PsiWcfService.svc HTTP/1.1\r\nContent-Type: text/xml\r\nSoapaction: http://www.paymentsolutionsinc.net/IPsiService/SendCreditCardPayment\r\nAccept-Encoding: identity\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: staging.paymentsolutionsinc.net\r\nContent-Length: 1768\r\n\r\n"
+      <- "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">\n  <s:Body>\n    <SendCreditCardPayment xmlns=\"http://www.paymentsolutionsinc.net/\">\n      <credentials xmlns:d4p1=\"http://schemas.datacontract.org/2004/07/PsiService\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\">\n        <d4p1:Password>password</d4p1:Password>\n        <d4p1:UserName>login</d4p1:UserName>\n      </credentials>\n      <paymentInfo xmlns:d4p1=\"http://schemas.datacontract.org/2004/07/PsiService\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\">\n        <d4p1:Amount>0.01</d4p1:Amount>\n        <d4p1:ClientTransactionId>1</d4p1:ClientTransactionId>\n        <d4p1:CreditCard>\n          <d4p1:CardNo>4111111111111111</d4p1:CardNo>\n          <d4p1:ExpMonth>05</d4p1:ExpMonth>\n          <d4p1:ExpYear>2017</d4p1:ExpYear>\n          <d4p1:Cvv>111</d4p1:Cvv>\n          <d4p1:Type>Visa</d4p1:Type>\n        </d4p1:CreditCard>\n        <d4p1:Donor>\n          <d4p1:Address1>street</d4p1:Address1>\n          <d4p1:City>some city</d4p1:City>\n          <d4p1:Employer/>\n          <d4p1:FirstName>Foo</d4p1:FirstName>\n          <d4p1:LastName>Bar</d4p1:LastName>\n          <d4p1:Phone>N/A</d4p1:Phone>\n          <d4p1:PostalCode>90210</d4p1:PostalCode>\n          <d4p1:SendEmail>false</d4p1:SendEmail>\n          <d4p1:StateProvince>a province of sorts</d4p1:StateProvince>\n          <d4p1:Address2>foo</d4p1:Address2>\n          <d4p1:Country>USA</d4p1:Country>\n        </d4p1:Donor>\n        <d4p1:Frequency>Monthly</d4p1:Frequency>\n        <d4p1:PayType>OneTime</d4p1:PayType>\n        <d4p1:ProcessDateTime>2016-05-10T14:34:23</d4p1:ProcessDateTime>\n      </paymentInfo>\n    </SendCreditCardPayment>\n  </s:Body>\n</s:Envelope>\n"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Content-Length: 876\r\n"
+      -> "Content-Type: text/xml; charset=utf-8\r\n"
+      -> "Server: Microsoft-IIS/7.5\r\n"
+      -> "X-Powered-By: ASP.NET\r\n"
+      -> "Date: Tue, 10 May 2016 04:34:24 GMT\r\n"
+      -> "Connection: close\r\n"
+      -> "\r\n"
+      reading 876 bytes...
+      -> "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\"><s:Body><SendCreditCardPaymentResponse xmlns=\"http://www.paymentsolutionsinc.net/\"><SendCreditCardPaymentResult xmlns:a=\"http://schemas.datacontract.org/2004/07/PsiService\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><a:AmountApproved>0.01</a:AmountApproved><a:Approved>true</a:Approved><a:AuthorizationCode>000000</a:AuthorizationCode><a:ClientTransactionId>922241624</a:ClientTransactionId><a:GatewayRawResponse i:nil=\"true\"/><a:ProcessedDateTime>2016-05-10T00:34:24.7814177-04:00</a:ProcessedDateTime><a:ReasonCode>1</a:ReasonCode><a:ResponseCode>1</a:ResponseCode><a:ResponseMessage>This transaction has been approved.</a:ResponseMessage><a:ResponseTime>1185.6021</a:ResponseTime><a:TransactionId>0</a:TransactionId></SendCreditCardPaymentResult></SendCreditCardPaymentResponse></s:Body></s:Envelope>"
+      read 876 bytes
+      Conn close
+    eos
+  end
+
+  def post_scrubbed
+    <<-eos
+      opening connection to staging.paymentsolutionsinc.net:443...
+      opened
+      starting SSL for staging.paymentsolutionsinc.net:443...
+      SSL established
+      <- "POST /Services/Aspca/Payment/PsiWcfService.svc HTTP/1.1\r\nContent-Type: text/xml\r\nSoapaction: http://www.paymentsolutionsinc.net/IPsiService/SendCreditCardPayment\r\nAccept-Encoding: identity\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: staging.paymentsolutionsinc.net\r\nContent-Length: 1768\r\n\r\n"
+      <- "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">\n  <s:Body>\n    <SendCreditCardPayment xmlns=\"http://www.paymentsolutionsinc.net/\">\n      <credentials xmlns:d4p1=\"http://schemas.datacontract.org/2004/07/PsiService\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\">\n        <d4p1:Password>[FILTERED]</d4p1:Password>\n        <d4p1:UserName>[FILTERED]</d4p1:UserName>\n      </credentials>\n      <paymentInfo xmlns:d4p1=\"http://schemas.datacontract.org/2004/07/PsiService\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\">\n        <d4p1:Amount>0.01</d4p1:Amount>\n        <d4p1:ClientTransactionId>1</d4p1:ClientTransactionId>\n        <d4p1:CreditCard>\n          <d4p1:CardNo>[FILTERED]</d4p1:CardNo>\n          <d4p1:ExpMonth>05</d4p1:ExpMonth>\n          <d4p1:ExpYear>2017</d4p1:ExpYear>\n          <d4p1:Cvv>[FILTERED]</d4p1:Cvv>\n          <d4p1:Type>Visa</d4p1:Type>\n        </d4p1:CreditCard>\n        <d4p1:Donor>\n          <d4p1:Address1>street</d4p1:Address1>\n          <d4p1:City>some city</d4p1:City>\n          <d4p1:Employer/>\n          <d4p1:FirstName>Foo</d4p1:FirstName>\n          <d4p1:LastName>Bar</d4p1:LastName>\n          <d4p1:Phone>N/A</d4p1:Phone>\n          <d4p1:PostalCode>90210</d4p1:PostalCode>\n          <d4p1:SendEmail>false</d4p1:SendEmail>\n          <d4p1:StateProvince>a province of sorts</d4p1:StateProvince>\n          <d4p1:Address2>foo</d4p1:Address2>\n          <d4p1:Country>USA</d4p1:Country>\n        </d4p1:Donor>\n        <d4p1:Frequency>Monthly</d4p1:Frequency>\n        <d4p1:PayType>OneTime</d4p1:PayType>\n        <d4p1:ProcessDateTime>2016-05-10T14:34:23</d4p1:ProcessDateTime>\n      </paymentInfo>\n    </SendCreditCardPayment>\n  </s:Body>\n</s:Envelope>\n"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Content-Length: 876\r\n"
+      -> "Content-Type: text/xml; charset=utf-8\r\n"
+      -> "Server: Microsoft-IIS/7.5\r\n"
+      -> "X-Powered-By: ASP.NET\r\n"
+      -> "Date: Tue, 10 May 2016 04:34:24 GMT\r\n"
+      -> "Connection: close\r\n"
+      -> "\r\n"
+      reading 876 bytes...
+      -> "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\"><s:Body><SendCreditCardPaymentResponse xmlns=\"http://www.paymentsolutionsinc.net/\"><SendCreditCardPaymentResult xmlns:a=\"http://schemas.datacontract.org/2004/07/PsiService\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><a:AmountApproved>0.01</a:AmountApproved><a:Approved>true</a:Approved><a:AuthorizationCode>000000</a:AuthorizationCode><a:ClientTransactionId>922241624</a:ClientTransactionId><a:GatewayRawResponse i:nil=\"true\"/><a:ProcessedDateTime>2016-05-10T00:34:24.7814177-04:00</a:ProcessedDateTime><a:ReasonCode>1</a:ReasonCode><a:ResponseCode>1</a:ResponseCode><a:ResponseMessage>This transaction has been approved.</a:ResponseMessage><a:ResponseTime>1185.6021</a:ResponseTime><a:TransactionId>0</a:TransactionId></SendCreditCardPaymentResult></SendCreditCardPaymentResponse></s:Body></s:Envelope>"
+      read 876 bytes
+      Conn close
+    eos
+
+  end
+
+  def successful_purchase_response
+    <<-eos
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+        <s:Body>
+          <SendCreditCardPaymentResponse xmlns="http://www.paymentsolutionsinc.net/">
+            <SendCreditCardPaymentResult xmlns:a="http://schemas.datacontract.org/2004/07/PsiService" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+              <a:AmountApproved>1.00</a:AmountApproved>
+              <a:Approved>true</a:Approved>
+              <a:AuthorizationCode>000000</a:AuthorizationCode>
+              <a:ClientTransactionId>922241628</a:ClientTransactionId>
+              <a:GatewayRawResponse i:nil="true"/>
+              <a:ProcessedDateTime>2016-05-10T00:41:14.9373381-04:00</a:ProcessedDateTime>
+              <a:ReasonCode>1</a:ReasonCode>
+              <a:ResponseCode>1</a:ResponseCode>
+              <a:ResponseMessage>This transaction has been approved.</a:ResponseMessage>
+              <a:ResponseTime>889.2015</a:ResponseTime>
+              <a:TransactionId>0</a:TransactionId>
+            </SendCreditCardPaymentResult>
+          </SendCreditCardPaymentResponse>
+        </s:Body>
+      </s:Envelope>
+    eos
+  end
+
+  def failed_purchase_response
+    <<-eos
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+        <s:Body>
+          <SendCreditCardPaymentResponse xmlns="http://www.paymentsolutionsinc.net/">
+            <SendCreditCardPaymentResult xmlns:a="http://schemas.datacontract.org/2004/07/PsiService" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+              <a:AmountApproved>2.00</a:AmountApproved>
+              <a:Approved>false</a:Approved>
+              <a:AuthorizationCode>000000</a:AuthorizationCode>
+              <a:ClientTransactionId>922241654</a:ClientTransactionId>
+              <a:GatewayRawResponse i:nil="true"/>
+              <a:ProcessedDateTime>2016-05-10T21:29:52.1657233-04:00</a:ProcessedDateTime>
+              <a:ReasonCode>2</a:ReasonCode>
+              <a:ResponseCode>2</a:ResponseCode>
+              <a:ResponseMessage>This transaction has been declined.</a:ResponseMessage>
+              <a:ResponseTime>842.4015</a:ResponseTime>
+              <a:TransactionId>0</a:TransactionId>
+            </SendCreditCardPaymentResult>
+          </SendCreditCardPaymentResponse>
+        </s:Body>
+      </s:Envelope>
+    eos
+  end
+end


### PR DESCRIPTION
PSI is not a gateway per-se, more like an NGO CRM that in term uses Authorized.net in the background. This implementation ONLY implements the `purchase` method as that's the only function we will be using for our customer. This implementation WILL NOT be pushed to ActiveMerchant as it's not a proper payment gateway and won't get merged, I suspect.

Note: the live_url has NOT been tested yet.

[#115453715]