### PR TITLE
Implement support for `store` and `unstore`

### DIFF
--- a/lib/active_merchant/billing/gateways/world_net.rb
+++ b/lib/active_merchant/billing/gateways/world_net.rb
@@ -20,41 +20,42 @@ module ActiveMerchant #:nodoc:
         american_express: 'AMEX',
         maestro:          'MAESTRO',
         diners_club:      'DINERS',
-        jcb:              'JCB'
-      }
+        jcb:              'JCB',
+        secure_card:      'SECURECARD'
+      }.freeze
       self.supported_cardtypes = CARD_TYPES.keys
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :terminal_id, :secret)
         options[:terminal_type] ||= 2 # eCommerce
         super
       end
 
-      def purchase(money, payment, options={})
+      def purchase(money, payment, options = {})
         requires!(options, :order_id)
 
         post = {}
         add_invoice(post, money, options)
         add_payment(post, payment)
-        add_address(post, payment, options)
+        add_address(post, options)
         add_customer_data(post, options)
 
         commit('PAYMENT', post)
       end
 
-      def authorize(money, payment, options={})
+      def authorize(money, payment, options = {})
         requires!(options, :order_id)
 
         post = {}
         add_invoice(post, money, options)
         add_payment(post, payment)
-        add_address(post, payment, options)
+        add_address(post, options)
         add_customer_data(post, options)
 
         commit('PREAUTH', post)
       end
 
-      def capture(money, authorization, options={})
+      def capture(money, authorization, options = {})
         post = {}
         add_invoice(post, money, options)
         post[:uniqueref] = authorization
@@ -62,7 +63,7 @@ module ActiveMerchant #:nodoc:
         commit('PREAUTHCOMPLETION', post)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         requires!(options, :operator, :reason)
 
         post = {}
@@ -74,17 +75,37 @@ module ActiveMerchant #:nodoc:
         commit('REFUND', post)
       end
 
-      def void(authorization, options={})
+      def void(authorization, options = {})
         post = {}
         post[:uniqueref] = authorization
         commit('VOID', post)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }
         end
+      end
+
+      def store(payment, options = {})
+        requires!(options, :order_id)
+
+        post = {}
+        post[:merchantref] = options[:order_id]
+        add_payment(post, payment)
+
+        commit('SECURECARDREGISTRATION', post)
+      end
+
+      def unstore(payment, options = {})
+        requires!(options, :order_id)
+
+        post = {}
+        post[:merchantref] = options[:order_id]
+        add_card_reference(post, payment)
+
+        commit('SECURECARDREMOVAL', post)
       end
 
       def supports_scrubbing?
@@ -104,7 +125,7 @@ module ActiveMerchant #:nodoc:
         post[:ipaddress] = options[:ip]
       end
 
-      def add_address(post, creditcard, options)
+      def add_address(post, options)
         address = options[:billing_address] || options[:address]
         return unless address
         post[:address1] = address[:address1]
@@ -122,11 +143,22 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_payment(post, payment)
-        post[:cardholdername]   = cardholdername(payment)
-        post[:cardtype]         = CARD_TYPES[payment.brand.to_sym]
-        post[:cardnumber]       = payment.number
-        post[:cvv]              = payment.verification_value
-        post[:cardexpiry]       = expdate(payment)
+        # a payment triggered with a secure_card (tokenised card) will not
+        # respond to `:number`
+        if payment.respond_to?(:number)
+          post[:cardholdername] = cardholdername(payment)
+          post[:cardtype]       = CARD_TYPES[payment.brand.to_sym]
+          post[:cardnumber]     = payment.number
+          post[:cvv]            = payment.verification_value if payment.verification_value
+          post[:cardexpiry]     = expdate(payment)
+        else
+          post[:cardtype]       = CARD_TYPES[:secure_card]
+          post[:cardnumber]     = payment
+        end
+      end
+
+      def add_card_reference(post, payment)
+        post[:cardreference] = payment
       end
 
       def cardholdername(payment)
@@ -148,19 +180,26 @@ module ActiveMerchant #:nodoc:
         response = parse(action, ssl_post(url, post_data(action, parameters)))
 
         Response.new(
-          success_from(response),
+          success_from(action, response),
           message_from(response),
           response,
-          authorization: authorization_from(response),
+          authorization: authorization_from(action, response),
           avs_result: AVSResult.new(code: response[:avs_response]),
           cvv_result: CVVResult.new(response[:cvv_response]),
           test: test?,
-          error_code: success_from(response) ? nil : message_to_standard_error_code_from(response)
+          error_code: success_from(action, response) ? nil : message_to_standard_error_code_from(response)
         )
       end
 
-      def success_from(response)
-        response[:responsecode] == 'A'
+      def success_from(action, response)
+        case action
+        when 'SECURECARDREGISTRATION'
+          response[:cardreference].present?
+        when 'SECURECARDREMOVAL'
+          response[:datetime].present? && response[:hash].present?
+        else
+          response[:responsecode] == 'A'
+        end
       end
 
       def message_to_standard_error_code_from(response)
@@ -180,8 +219,13 @@ module ActiveMerchant #:nodoc:
         response[:responsetext] || response[:errorstring]
       end
 
-      def authorization_from(response)
-        response[:uniqueref]
+      def authorization_from(action, response)
+        case action
+        when 'SECURECARDREGISTRATION'
+          response[:cardreference]
+        else
+          response[:uniqueref]
+        end
       end
 
       def post_data(action, parameters = {})
@@ -189,7 +233,14 @@ module ActiveMerchant #:nodoc:
         parameters[:terminaltype]     = @options[:terminal_type]
         parameters[:transactiontype]  = 7 # eCommerce
         parameters[:datetime]         = create_time_stamp
-        parameters[:hash]             = build_signature(parameters)
+        parameters[:hash]             = case action
+                                        when 'SECURECARDREGISTRATION'
+                                          build_store_signature(parameters)
+                                        when 'SECURECARDREMOVAL'
+                                          build_unstore_signature(parameters)
+                                        else
+                                          build_signature(parameters)
+                                        end
         build_xml_request(action, fields(action), parameters)
       end
 
@@ -201,6 +252,25 @@ module ActiveMerchant #:nodoc:
         str = parameters[:terminalid]
         str += (parameters[:uniqueref] || parameters[:orderid])
         str += (parameters[:amount].to_s + parameters[:datetime])
+        Digest::MD5.hexdigest(str + @options[:secret])
+      end
+
+      def build_store_signature(parameters)
+        str = parameters[:terminalid]
+        str += parameters[:merchantref]
+        str += parameters[:datetime]
+        str += parameters[:cardnumber]
+        str += parameters[:cardexpiry]
+        str += parameters[:cardtype]
+        str += parameters[:cardholdername]
+        Digest::MD5.hexdigest(str + @options[:secret])
+      end
+
+      def build_unstore_signature(parameters)
+        str = parameters[:terminalid]
+        str += parameters[:merchantref]
+        str += parameters[:datetime]
+        str += parameters[:cardreference]
         Digest::MD5.hexdigest(str + @options[:secret])
       end
 
@@ -233,6 +303,25 @@ module ActiveMerchant #:nodoc:
            :operator, :reason]
         when 'VOID'
           [:uniqueref]
+        when 'SECURECARDREGISTRATION'
+          [
+            :merchantref,
+            :terminalid,
+            :datetime,
+            :cardnumber, :cardexpiry, :cardtype, :cardholdername,
+            :hash,
+            :dontchecksecurity,
+            :cvv,
+            :issueno
+          ]
+        when 'SECURECARDREMOVAL'
+          [
+            :merchantref,
+            :cardreference,
+            :terminalid,
+            :datetime,
+            :hash
+          ]
         end
       end
 

--- a/test/unit/gateways/world_net_test.rb
+++ b/test/unit/gateways/world_net_test.rb
@@ -111,6 +111,30 @@ class WorldNetTest < Test::Unit::TestCase
     assert_equal 'DECLINED', response.message
   end
 
+  def test_successful_store
+    @gateway.expects(:ssl_post).returns(successful_store_response)
+    response = @gateway.store(credit_card, @options)
+    assert_success response
+  end
+
+  def test_unsuccessful_store
+    @gateway.expects(:ssl_post).returns(failed_store_response)
+    response = @gateway.store(credit_card, @options)
+    assert_failure response
+  end
+
+  def test_successful_unstore
+    @gateway.expects(:ssl_post).returns(successful_unstore_response)
+    response = @gateway.unstore('4111111111111111', @options)
+    assert_success response
+  end
+
+  def test_unsuccessful_unstore
+    @gateway.expects(:ssl_post).returns(failed_unstore_response)
+    response = @gateway.unstore('4111111111111111', @options)
+    assert_failure response
+  end
+
   def test_scrub
     assert @gateway.supports_scrubbing?
     assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
@@ -207,6 +231,26 @@ Conn close
   end
 
   def successful_void_response
+  end
+
+  def successful_store_response
+    %q(<?xml version="1.0" encoding="UTF-8"?>
+<SECURECARDREGISTRATIONRESPONSE><MERCHANTREF>146304412401</MERCHANTREF><CARDREFERENCE>2967530956419033</CARDREFERENCE><DATETIME>12-05-2016:10:08:46:269</DATETIME><HASH>b2e497d14014ad9f4770edbf7716435e</HASH></SECURECARDREGISTRATIONRESPONSE>)
+  end
+
+  def failed_store_response
+    %q(<?xml version="1.0" encoding="UTF-8"?>
+<ERROR><ERRORCODE>E11</ERRORCODE><ERRORSTRING>INVALID CARDEXPIRY</ERRORSTRING></ERROR>)
+  end
+
+  def successful_unstore_response
+    %q(<?xml version="1.0" encoding="UTF-8"?>
+<SECURECARDREMOVALRESPONSE><MERCHANTREF>146304412401</MERCHANTREF><DATETIME>12-05-2016:10:08:48:399</DATETIME><HASH>7f755e185be8066a535699755f709646</HASH></SECURECARDREMOVALRESPONSE>)
+  end
+
+  def failed_unstore_response
+    %q(<?xml version="1.0" encoding="UTF-8"?>
+<ERROR><ERRORCODE>E04</ERRORCODE><ERRORSTRING>INVALID REFERENCE DETAILS</ERRORSTRING></ERROR>)
   end
 
   def failed_void_response


### PR DESCRIPTION
This commit adds support for the `store` and `unstore` methods (secure card registration and removal), fixes a few rubocop warnings.