### PR TITLE
Adds basic tokenisation support for banwire

### DIFF
--- a/lib/active_merchant/billing/gateways/banwire.rb
+++ b/lib/active_merchant/billing/gateways/banwire.rb
@@ -119,18 +119,18 @@ module ActiveMerchant #:nodoc:
           response = json_error(raw_response)
         end
 
-        Response.new(success?(action, response),
+        Response.new(success?(response, action),
                      response["message"],
                      response,
                      :test => test?,
-                     :authorization => authorization_from_response(action, response))
+                     :authorization => authorization_from_response(response, action))
       end
 
-      def authorization_from_response(action, response)
+      def authorization_from_response(response, action)
         action == 'store' ? response['token'] : response['code_auth']
       end
 
-      def success?(action, response)
+      def success?(response, action)
         action == 'store' ? response['result'] : response['response'] == "ok"
       end
 

--- a/lib/active_merchant/billing/gateways/banwire.rb
+++ b/lib/active_merchant/billing/gateways/banwire.rb
@@ -2,6 +2,7 @@ module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class BanwireGateway < Gateway
       URL = 'https://banwire.com/api.pago_pro'
+      URL_STORE = 'https://cr.banwire.com/?action=card'
 
       self.supported_countries = ['MX']
       self.supported_cardtypes = [:visa, :master, :american_express]
@@ -20,10 +21,18 @@ module ActiveMerchant #:nodoc:
         add_order_data(post, options)
         add_creditcard(post, creditcard)
         add_address(post, creditcard, options)
-        add_customer_data(post, options)
         add_amount(post, money, options)
 
-        commit(money, post)
+        commit(money, post, 'purchase')
+      end
+
+      def store(creditcard, options = {})
+        post = {}
+        add_response_type(post)
+        add_card_details_store(post, creditcard)
+        add_customer_data_store(post, options)
+
+        commit(nil, post, 'store')
       end
 
       def supports_scrubbing?
@@ -72,6 +81,23 @@ module ActiveMerchant #:nodoc:
         post[:currency] = options[:currency]
       end
 
+      # the banwire API for tokenisation expects different parameter names
+      def add_card_details_store(post, creditcard)
+        post[:number] = creditcard.number
+        post[:exp_month] = creditcard.month
+        post[:exp_year] = creditcard.year
+        post[:cvv] = creditcard.verification_value || '123'
+        post[:name] = creditcard.name
+      end
+
+      def add_customer_data_store(post, options)
+        post[:method] = 'add'
+        post[:user] = @options[:login]
+        post[:address] = options[:billing_address][:address1]
+        post[:postal_code] = options[:billing_address][:zip]
+        post[:email] = options[:email] || "unspecified@email.com"
+      end
+
       def card_brand(card)
         brand = super
         ({"master" => "mastercard", "american_express" => "amex"}[brand] || brand)
@@ -81,23 +107,31 @@ module ActiveMerchant #:nodoc:
         JSON.parse(body)
       end
 
-      def commit(money, parameters)
-        raw_response = ssl_post(URL, post_data(parameters))
+      def url(action)
+        action == 'purchase' ? URL : URL_STORE
+      end
+
+      def commit(money = nil, parameters, action)
+        raw_response = ssl_post(url(action), post_data(parameters))
         begin
           response = parse(raw_response)
         rescue JSON::ParserError
           response = json_error(raw_response)
         end
 
-        Response.new(success?(response),
+        Response.new(success?(action, response),
                      response["message"],
                      response,
                      :test => test?,
-                     :authorization => response["code_auth"])
+                     :authorization => authorization_from_response(action, response))
       end
 
-      def success?(response)
-        (response["response"] == "ok")
+      def authorization_from_response(action, response)
+        action == 'store' ? response['token'] : response['code_auth']
+      end
+
+      def success?(action, response)
+        action == 'store' ? response['result'] : response['response'] == "ok"
       end
 
       def post_data(parameters = {})

--- a/test/remote/gateways/remote_banwire_test.rb
+++ b/test/remote/gateways/remote_banwire_test.rb
@@ -53,14 +53,24 @@ class RemoteBanwireTest < Test::Unit::TestCase
     assert_equal 'ID de cuenta invalido', response.message
   end
 
-def test_transcript_scrubbing
-  transcript = capture_transcript(@gateway) do
-    @gateway.purchase(@amount, @credit_card, @options)
+  def test_successful_store
+    assert response = @gateway.store(credit_card, @options)
+    assert_success = response
   end
-  clean_transcript = @gateway.scrub(transcript)
 
-  assert_scrubbed(@credit_card.number, clean_transcript)
-  assert_scrubbed(@credit_card.verification_value.to_s, clean_transcript)
-end
+  def test_unsuccessful_store
+    assert response = @gateway.store(credit_card('4000300011112220', month: 13), @options)
+    assert_failure = response
+  end
+
+  def test_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end
+    clean_transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card.number, clean_transcript)
+    assert_scrubbed(@credit_card.verification_value.to_s, clean_transcript)
+  end
 
 end

--- a/test/unit/gateways/banwire_test.rb
+++ b/test/unit/gateways/banwire_test.rb
@@ -85,6 +85,14 @@ class BanwireTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_store
+    @gateway.expects(:ssl_post).returns(successful_store_response)
+    
+    assert response = @gateway.store(@credit_card, @options)
+    assert_success response
+    assert_match /crd\./, response.authorization
+  end
+
   def test_transcript_scrubbing
     assert_equal scrubbed_transcript, @gateway.scrub(transcript)
   end
@@ -113,6 +121,18 @@ class BanwireTest < Test::Unit::TestCase
   def successful_purchase_amex_response
     <<-RESPONSE
     {"user":"desarrollo","id":"20120731153834","referencia":"12345","date":"31-07-2012 15:38:34","card":"99999","response":"ok","code_auth":"test12345","monto":0.5,"client":"Banwire Test Card"}
+    RESPONSE
+  end
+
+  def successful_store_response
+    <<-RESPONSE
+    {"id":174552,"token":"crd.1KsWZShnfhXEfovotoATEN22Hpft","task":"add","result":true,"exists":false,"card":{"type":"credit","category":"classic"}}
+    RESPONSE
+  end
+
+  def failed_store_response
+    <<-RESPONSE
+    {"error":"Card already exists"}
     RESPONSE
   end
 


### PR DESCRIPTION
This commit adds support for tokenisation via the `recurrentes` API
http://docs.banwire.com/recurrentes to Banwire.

The one off payments for tokens seems to require an account, I have not
added tests for that yet.

[#119226831]