### PR TITLE
Add ability to pass market source in payment info

### DIFF
--- a/lib/active_merchant/billing/gateways/payment_solutions.rb
+++ b/lib/active_merchant/billing/gateways/payment_solutions.rb
@@ -113,6 +113,7 @@ module ActiveMerchant #:nodoc:
 
       def add_payment(xml, options={})
         xml['d4p1'].Frequency empty?(options[:frequency]) ? 'Monthly' : options[:frequency]
+        xml['d4p1'].MarketSource truncate(options[:market_source], 200) if options[:market_source].present?
         xml['d4p1'].PayCode options[:pay_code] if options[:pay_code].present?
         xml['d4p1'].PayType empty?(options[:pay_type]) ? 'OneTime' : options[:pay_type]
         xml['d4p1'].ProcessDateTime Time.current.strftime("%FT%T")

--- a/test/remote/gateways/remote_payment_solutions_test.rb
+++ b/test/remote/gateways/remote_payment_solutions_test.rb
@@ -38,7 +38,8 @@ class RemotePaymentSolutionsTest < Test::Unit::TestCase
       ip: "127.0.0.1",
       email: "joe@example.com",
       program_code: '1',
-      pay_code: 'IGS25XX46027DCP'
+      pay_code: 'IGS25XX46027DCP',
+      market_source: SecureRandom.uuid
     }
 
     @options.merge!(more_options)
@@ -56,7 +57,8 @@ class RemotePaymentSolutionsTest < Test::Unit::TestCase
       ip: "127.0.0.1",
       email: "joe@example.com",
       program_code: '2',
-      pay_code: 'IGS25XX46027DCP'
+      pay_code: 'IGS25XX46027DCP',
+      market_source: SecureRandom.uuid
     }
 
     @options.merge!(more_options)


### PR DESCRIPTION
This adds the ability to pass an additional option, `:market_source` (which can be up to 200 chars).

[#120107569]