### PR TITLE
Pass true to SendEmail when address[:email] exists

### DIFF
--- a/lib/active_merchant/billing/gateways/payment_solutions.rb
+++ b/lib/active_merchant/billing/gateways/payment_solutions.rb
@@ -95,7 +95,7 @@ module ActiveMerchant #:nodoc:
           xml['d4p1'].LastName payment.last_name
           xml['d4p1'].Phone address[:phone] if address[:phone]
           xml['d4p1'].PostalCode address[:zip] if address[:zip]
-          xml['d4p1'].SendEmail false
+          xml['d4p1'].SendEmail address[:email].nil? ? false : true
           xml['d4p1'].StateProvince address[:state] if address[:state]
           xml['d4p1'].Address2 address[:address2] if address[:address2]
           xml['d4p1'].Country address[:country] if address[:country]

--- a/lib/active_merchant/billing/gateways/payment_solutions.rb
+++ b/lib/active_merchant/billing/gateways/payment_solutions.rb
@@ -95,7 +95,7 @@ module ActiveMerchant #:nodoc:
           xml['d4p1'].LastName payment.last_name
           xml['d4p1'].Phone address[:phone] if address[:phone]
           xml['d4p1'].PostalCode address[:zip] if address[:zip]
-          xml['d4p1'].SendEmail address[:email].nil? ? false : true
+          xml['d4p1'].SendEmail address[:email].present?
           xml['d4p1'].StateProvince address[:state] if address[:state]
           xml['d4p1'].Address2 address[:address2] if address[:address2]
           xml['d4p1'].Country address[:country] if address[:country]

--- a/test/remote/gateways/remote_payment_solutions_test.rb
+++ b/test/remote/gateways/remote_payment_solutions_test.rb
@@ -36,7 +36,12 @@ class RemotePaymentSolutionsTest < Test::Unit::TestCase
     more_options = {
       order_id: '2',
       ip: "127.0.0.1",
-      email: "joe@example.com",
+      billing_address: address({
+        city:     'Hollywood',
+        state:    'CA',
+        zip:      '90210',
+        country:  'USA',
+        email: "joe@example.com",}),
       program_code: '1',
       pay_code: 'IGS25XX46027DCP',
       market_source: SecureRandom.uuid


### PR DESCRIPTION
During the development of this gateway implementation, I hardcoded `false` in `Donor.SendEmail` however the correct implementation should check if the `address[:email]` parameter has been supplied and change between `true` and `false` accordingly.

[#122001267]