### PR TITLE
[Banwire] Add extra parameter to store URL

### DIFF
--- a/lib/active_merchant/billing/gateways/banwire.rb
+++ b/lib/active_merchant/billing/gateways/banwire.rb
@@ -2,7 +2,10 @@ module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class BanwireGateway < Gateway
       URL = 'https://banwire.com/api.pago_pro'
-      URL_STORE = 'https://cr.banwire.com/?action=card'
+      # the &exists=1 additional parameter is supplied to ensure
+      # that repeated attempts to store the same PAN will not yield
+      # an exception and instead will return the token again
+      URL_STORE = 'https://cr.banwire.com/?action=card&exists=1'
 
       self.supported_countries = ['MX']
       self.supported_cardtypes = [:visa, :master, :american_express]

--- a/test/remote/gateways/remote_banwire_test.rb
+++ b/test/remote/gateways/remote_banwire_test.rb
@@ -56,6 +56,7 @@ class RemoteBanwireTest < Test::Unit::TestCase
   def test_successful_store
     assert response = @gateway.store(credit_card, @options)
     assert_success = response
+    assert response.authorization =~ /crd\./
   end
 
   def test_unsuccessful_store
@@ -70,7 +71,11 @@ class RemoteBanwireTest < Test::Unit::TestCase
     clean_transcript = @gateway.scrub(transcript)
 
     assert_scrubbed(@credit_card.number, clean_transcript)
-    assert_scrubbed(@credit_card.verification_value.to_s, clean_transcript)
+    # we force the check on the param name since the test card number from Banwire contains the
+    # same digits we are trying to verify are not present, the response from the gateway
+    # contains the last few digits from the card, which are the same as the CVV.
+    # If we supply a different CVV, say 888, Banwire fails the test transactions.
+    assert_scrubbed("card_ccv2=#{@credit_card.verification_value.to_s}", clean_transcript)
   end
 
 end


### PR DESCRIPTION
This ensure that Banwire will not return the exception `{"error":"Card
already exists"}` when attempting to tokenise a PAN that was already
stored. It will, instead return the token for the given PAN.
