### PR TITLE
Only get alpha2 country code when it's a known country

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -653,7 +653,7 @@ module ActiveMerchant #:nodoc:
 
       def lookup_country_code(country_field)
         country_code = Country.find(country_field) rescue nil
-        country_code.code(:alpha2)
+        country_code.code(:alpha2) if country_code
       end
 
       # Where we actually build the full SOAP request using builder


### PR DESCRIPTION
Fixes the case when the country code lookup in Cybersource would fail
(for example when using `Faker::Address.country`). Only attempt to call
`.code(:alpha2)` when `country_code` is not `nil`.
