### PR TITLE
Implement store for Flo2Cash

### DIFF
--- a/lib/active_merchant/billing/gateways/flo2cash.rb
+++ b/lib/active_merchant/billing/gateways/flo2cash.rb
@@ -25,10 +25,18 @@ module ActiveMerchant #:nodoc:
       end
 
       def purchase(amount, payment_method, options={})
-        MultiResponse.run do |r|
-          r.process { authorize(amount, payment_method, options) }
-          r.process { capture(amount, r.authorization, options) }
+        post = {}
+        add_invoice(post, amount, options)
+        action = 'ProcessPurchase'
+        if payment_method.is_a?(String)
+          add_card_token(post, payment_method)
+          action = 'ProcessPurchaseByToken'
+        else
+          add_payment_method(post, payment_method)
         end
+        add_customer_data(post, options)
+
+        commit(action, post)
       end
 
       def authorize(amount, payment_method, options={})
@@ -37,7 +45,7 @@ module ActiveMerchant #:nodoc:
         add_payment_method(post, payment_method)
         add_customer_data(post, options)
 
-        commit("ProcessAuthorise", post)
+        commit('ProcessAuthorise', post)
       end
 
       def capture(amount, authorization, options={})
@@ -56,6 +64,25 @@ module ActiveMerchant #:nodoc:
         add_customer_data(post, options)
 
         commit("ProcessRefund", post)
+      end
+
+      def store(payment_method, options={})
+        post = {}
+        add_payment_method(post, payment_method)
+        action = 'AddCard'
+        if options[:order_id].present?
+          add_unique_reference(post, options[:order_id])
+          action = 'AddCardWithUniqueReference'
+        end
+
+        commit(action, post)
+      end
+
+      def unstore(authorization, options={})
+        post = {}
+        add_card_token(post, authorization)
+
+        commit('RemoveCard', post)
       end
 
       def supports_scrubbing?
@@ -85,7 +112,7 @@ module ActiveMerchant #:nodoc:
         post[:CardType] = BRAND_MAP[payment_method.brand.to_s]
         post[:CardExpiry] = format(payment_method.month, :two_digits) + format(payment_method.year, :two_digits)
         post[:CardHolderName] = payment_method.name
-        post[:CardCSC] = payment_method.verification_value
+        post[:CardCSC] = payment_method.verification_value if payment_method.verification_value
       end
 
       def add_customer_data(post, options)
@@ -94,18 +121,43 @@ module ActiveMerchant #:nodoc:
         end
       end
 
+      def add_unique_reference(post, order_id)
+        post[:UniqueReference] = order_id
+      end
+
+      def add_card_token(post, authorization)
+        post[:CardToken] = authorization
+      end
+
       def add_reference(post, authorization)
         post[:OriginalTransactionId] = authorization
+      end
+
+      # helper used throughout to verify if we're 
+      def store_action?(action)
+        %w(AddCard AddCardWithUniqueReference RemoveCard).include? action
+      end
+
+      def store_url
+        host = (test? ? 'demo' : 'secure')
+
+        "https://#{host}.flo2cash.co.nz/ccws/tokenmanagement.asmx"
+      end
+
+      def set_endpoint(action)
+        store_action?(action) ? 'creditcardwebservice' : 'paymentwebservice'
       end
 
       def commit(action, post)
         post[:Username] = @options[:username]
         post[:Password] = @options[:password]
-        post[:AccountId] = @options[:account_id]
+        post[:AccountId] = @options[:account_id] unless store_action?(action)
 
-        data = build_request(action, post)
+        endpoint = set_endpoint(action)
+
+        data = build_request(action, endpoint, post)
         begin
-          raw = parse(ssl_post(url, data, headers(action)), action)
+          raw = parse(ssl_post(url(action), data, headers(action, endpoint)), action)
         rescue ActiveMerchant::ResponseError => e
           if(e.response.code == "500" && e.response.body.start_with?("<?xml"))
             raw = parse(e.response.body, action)
@@ -114,39 +166,43 @@ module ActiveMerchant #:nodoc:
           end
         end
 
-        succeeded = success_from(raw[:status])
+        succeeded = if store_action?(action)
+            success_from(raw["#{action.underscore}_result".to_sym])
+          else
+            success_from(raw[:status])
+          end
         Response.new(
           succeeded,
           message_from(succeeded, raw),
           raw,
-          :authorization => authorization_from(action, raw[:transaction_id], post[:OriginalTransactionId]),
+          :authorization => authorization_from(action, raw, post[:OriginalTransactionId]),
           :error_code => error_code_from(succeeded, raw),
           :test => test?
         )
       end
 
-      def headers(action)
+      def headers(action, endpoint)
         {
           'Content-Type'  => 'application/soap+xml; charset=utf-8',
-          'SOAPAction'    => %{"http://www.flo2cash.co.nz/webservices/paymentwebservice/#{action}"}
+          'SOAPAction'    => %{"http://www.flo2cash.co.nz/webservices/#{endpoint}/#{action}"}
         }
       end
 
-      def build_request(action, post)
+      def build_request(action, endpoint, post)
         xml = Builder::XmlMarkup.new :indent => 2
         post.each do |field, value|
           xml.tag!(field, value)
         end
         body = xml.target!
-        envelope_wrap(action, body)
+        envelope_wrap(action, endpoint, body)
       end
 
-      def envelope_wrap(action, body)
+      def envelope_wrap(action, endpoint, body)
         <<-EOS
 <?xml version="1.0" encoding="utf-8"?>
 <soap12:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap12="http://www.w3.org/2003/05/soap-envelope">
   <soap12:Body>
-    <#{action} xmlns="http://www.flo2cash.co.nz/webservices/paymentwebservice">
+    <#{action} xmlns="http://www.flo2cash.co.nz/webservices/#{endpoint}">
       #{body}
     </#{action}>
   </soap12:Body>
@@ -154,8 +210,8 @@ module ActiveMerchant #:nodoc:
         EOS
       end
 
-      def url
-        (test? ? test_url : live_url)
+      def url(action)
+        (store_action?(action) ? store_url : (test? ? test_url : live_url))
       end
 
       def parse(body, action)
@@ -178,8 +234,11 @@ module ActiveMerchant #:nodoc:
         end
       end
 
+      # response will contain the card token when calling a `store` action
+      # unfortunately the Flo2Cash doesn't seem to have a value one can use
+      # to verify success in the AddCard* methods
       def success_from(response)
-        response == 'SUCCESSFUL'
+        response == 'SUCCESSFUL' || response =~ /^\d+$/ || response == 'true'
       end
 
       def message_from(succeeded, response)
@@ -190,12 +249,14 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def authorization_from(action, current, original)
+      def authorization_from(action, raw, original)
         # Refunds require the authorization from the authorize() of the MultiResponse.
         if action == 'ProcessCapture'
           original
+        elsif store_action?(action)
+          raw["#{action.underscore}_result".to_sym]
         else
-          current
+          raw[:transaction_id]
         end
       end
 
@@ -205,6 +266,7 @@ module ActiveMerchant #:nodoc:
         'Insufficient Funds' => STANDARD_ERROR_CODE[:card_declined],
         'Transaction Declined - Bank Error' => STANDARD_ERROR_CODE[:processing_error],
         'No Reply from Bank' => STANDARD_ERROR_CODE[:processing_error],
+        'Card number must be a valid credit card number' => STANDARD_ERROR_CODE[:invalid_number],
       }
 
       def error_code_from(succeeded, response)

--- a/test/unit/gateways/flo2cash_test.rb
+++ b/test/unit/gateways/flo2cash_test.rb
@@ -19,24 +19,22 @@ class Flo2cashTest < Test::Unit::TestCase
   def test_successful_purchase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, order_id: "boom")
-    end.check_request do |endpoint, data, headers|
-      assert_match(%r{<Reference>boom</Reference>}, data)
-    end.respond_with(successful_authorize_response, successful_capture_response)
+    end.respond_with(successful_purchase_response)
 
     assert_success response
 
-    assert_equal "P150100005006789", response.authorization
+    assert_equal "P1610W0005138048", response.authorization
     assert response.test?
   end
 
   def test_failed_purchase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card)
-    end.respond_with(failed_authorize_response)
+    end.respond_with(failed_purchase_response)
 
     assert_failure response
     assert_equal "Transaction Declined - Bank Error", response.message
-    assert_equal Gateway::STANDARD_ERROR_CODE[:processing_error], response.responses.first.error_code
+    assert_equal Gateway::STANDARD_ERROR_CODE[:processing_error], response.error_code
     assert response.test?
   end
 
@@ -71,15 +69,15 @@ class Flo2cashTest < Test::Unit::TestCase
   def test_successful_refund
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card)
-    end.respond_with(successful_authorize_response, successful_capture_response)
+    end.respond_with(successful_purchase_response)
 
     assert_success response
-    assert_equal "P150100005006789", response.authorization
+    assert_equal "P1610W0005138048", response.authorization
 
     refund = stub_comms do
       @gateway.refund(@amount, response.authorization)
     end.check_request do |endpoint, data, headers|
-      assert_match(/P150100005006789/, data)
+      assert_match(/P1610W0005138048/, data)
     end.respond_with(successful_refund_response)
 
     assert_success refund
@@ -100,6 +98,73 @@ class Flo2cashTest < Test::Unit::TestCase
     assert_scrubbed(@credit_card.number, transcript)
     assert_scrubbed(@credit_card.verification_value, transcript)
     assert_scrubbed(@gateway.options[:password], transcript)
+  end
+
+  def test_successful_store
+    response = stub_comms do
+      @gateway.store(@credit_card)
+    end.respond_with(successful_store_response)
+
+    assert_success response
+    assert_equal '25223239884', response.authorization
+  end
+
+  def test_failed_store
+    response = stub_comms do
+      @gateway.store(@credit_card)
+    end.respond_with(failed_store_response)
+
+    assert_failure response
+    assert_equal 'Card number must be a valid credit card number', response.message
+  end
+
+  def test_successful_unstore
+    response = stub_comms do
+      @gateway.store(@credit_card)
+    end.respond_with(successful_store_response)
+
+    assert_success response
+    assert_equal '25223239884', response.authorization
+
+    unstore = stub_comms do
+      @gateway.unstore(response.authorization)
+    end.respond_with(successful_unstore_response)
+
+    assert_success unstore
+  end
+
+  def test_failed_unstore
+    response = stub_comms do
+      @gateway.unstore('12345')
+    end.respond_with(failed_unstore_response)
+
+    assert_failure response
+    assert_equal 'Card token not found', response.message
+  end
+
+  def test_successful_purchase_with_token
+    response = stub_comms do
+      @gateway.store(@credit_card)
+    end.respond_with(successful_store_response)
+
+    assert_success response
+    assert_equal '25223239884', response.authorization
+
+    purchase = stub_comms do
+      @gateway.purchase(@amount, response.authorization)
+    end.respond_with(successful_purchase_with_token_response)
+
+    assert_success purchase
+    assert_equal 'P1610W0005138055', purchase.authorization
+  end
+
+  def test_failed_purchase_with_token
+    purchase = stub_comms do
+      @gateway.purchase(@amount, '12345')
+    end.respond_with(failed_purchased_with_token_response)
+
+    assert_failure purchase
+    assert_equal 'Card token not found', purchase.message
   end
 
   private
@@ -124,12 +189,60 @@ class Flo2cashTest < Test::Unit::TestCase
 
   def successful_refund_response
     %(
-      <?xml version=\"1.0\" encoding=\"utf-8\"?><soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><soap:Body><ProcessRefundResponse xmlns=\"http://www.flo2cash.co.nz/webservices/paymentwebservice\"><transactionresult><TransactionId>P150100005006770</TransactionId><OriginalTransactionId>P150100005006769</OriginalTransactionId><Type>REFUND</Type><AccountId>621366</AccountId><Status>SUCCESSFUL</Status><ReceiptNumber>25001352</ReceiptNumber><AuthCode>039241</AuthCode><Amount>100</Amount><Reference /><Particular /><Message>Transaction Successful</Message><BlockedReason /><CardStored>false</CardStored><CardToken /></transactionresult></ProcessRefundResponse></soap:Body></soap:Envelope>
+      <?xml version=\"1.0\" encoding=\"utf-8\"?><soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><soap:Body><ProcessRefundResponse xmlns=\"http://www.flo2cash.co.nz/webservices/paymentwebservice\"><transactionresult><TransactionId>P1610W0005138053</TransactionId><OriginalTransactionId>P1610W0005138052</OriginalTransactionId><Type>REFUND</Type><AccountId>621462</AccountId><Status>SUCCESSFUL</Status><ReceiptNumber>25162085</ReceiptNumber><AuthCode>425730</AuthCode><Amount>1.00</Amount><Reference /><Particular /><Message>Transaction Successful</Message><BlockedReason /><CardStored>false</CardStored><CardToken /></transactionresult></ProcessRefundResponse></soap:Body></soap:Envelope>
     )
   end
 
   def empty_purchase_response
     %(
+    )
+  end
+
+  def successful_purchase_response
+    %(
+      <?xml version=\"1.0\" encoding=\"utf-8\"?><soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><soap:Body><ProcessPurchaseResponse xmlns=\"http://www.flo2cash.co.nz/webservices/paymentwebservice\"><transactionresult><TransactionId>P1610W0005138048</TransactionId><OriginalTransactionId /><Type>PURCHASE</Type><AccountId>621462</AccountId><Status>SUCCESSFUL</Status><ReceiptNumber>25162080</ReceiptNumber><AuthCode>915933</AuthCode><Amount>1.00</Amount><Reference>4dad48e7ca579b597963bab9635761c0</Reference><Particular>Store Purchase</Particular><Message>Transaction Successful</Message><BlockedReason /><CardStored>false</CardStored><CardToken /></transactionresult></ProcessPurchaseResponse></soap:Body></soap:Envelope>
+    )
+  end
+
+  def failed_purchase_response
+    %(
+      <?xml version=\"1.0\" encoding=\"utf-8\"?><soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><soap:Body><ProcessPurchaseResponse xmlns=\"http://www.flo2cash.co.nz/webservices/paymentwebservice\"><transactionresult><TransactionId>P1610W0005138051</TransactionId><OriginalTransactionId /><Type>PURCHASE</Type><AccountId>621462</AccountId><Status>FAILED</Status><ReceiptNumber>0</ReceiptNumber><AuthCode /><Amount>1.10</Amount><Reference>591f9a1e8fbe4fb8ff82ea628e7ae3ea</Reference><Particular>Store Purchase</Particular><Message>Transaction Declined - Bank Error</Message><BlockedReason /><CardStored>false</CardStored><CardToken /></transactionresult></ProcessPurchaseResponse></soap:Body></soap:Envelope>
+    )
+  end
+
+  def successful_store_response
+    %(
+      <?xml version=\"1.0\" encoding=\"utf-8\"?><soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><soap:Body><AddCardResponse xmlns=\"http://www.flo2cash.co.nz/webservices/creditcardwebservice\"><AddCardResult>25223239884</AddCardResult></AddCardResponse></soap:Body></soap:Envelope>
+    )
+  end
+
+  def failed_store_response
+    %(
+      <?xml version=\"1.0\" encoding=\"utf-8\"?><soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><soap:Body><soap:Fault><soap:Code><soap:Value>soap:Sender</soap:Value></soap:Code><soap:Reason><soap:Text xml:lang=\"en\">Card number must be a valid credit card number</soap:Text></soap:Reason><soap:Node>AddCard</soap:Node><detail><error><errortype>Parameter</errortype><errornumber>1002</errornumber><errormessage>Card number must be a valid credit card number</errormessage></error></detail></soap:Fault></soap:Body></soap:Envelope>
+    )
+  end
+
+  def successful_unstore_response
+    %(
+      <?xml version=\"1.0\" encoding=\"utf-8\"?><soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><soap:Body><RemoveCardResponse xmlns=\"http://www.flo2cash.co.nz/webservices/creditcardwebservice\"><RemoveCardResult>true</RemoveCardResult></RemoveCardResponse></soap:Body></soap:Envelope>
+    )
+  end
+
+  def failed_unstore_response
+    %(
+      <?xml version=\"1.0\" encoding=\"utf-8\"?><soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><soap:Body><soap:Fault><soap:Code><soap:Value>soap:Sender</soap:Value></soap:Code><soap:Reason><soap:Text xml:lang=\"en\">Card token not found</soap:Text></soap:Reason><soap:Node>RemoveCard</soap:Node><detail><error><errortype>Parameter</errortype><errornumber>2000</errornumber><errormessage>Card token not found</errormessage></error></detail></soap:Fault></soap:Body></soap:Envelope>
+    )
+  end
+
+  def successful_purchase_with_token_response
+    %(
+      <?xml version=\"1.0\" encoding=\"utf-8\"?><soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><soap:Body><ProcessPurchaseByTokenResponse xmlns=\"http://www.flo2cash.co.nz/webservices/paymentwebservice\"><transactionresult><TransactionId>P1610W0005138055</TransactionId><OriginalTransactionId /><Type>PURCHASE</Type><AccountId>621462</AccountId><Status>SUCCESSFUL</Status><ReceiptNumber>25162087</ReceiptNumber><AuthCode>943672</AuthCode><Amount>1.00</Amount><Reference>4a669b0e31206b57b7088e4f9433025a</Reference><Particular>Store Purchase</Particular><Message>Transaction Successful</Message><BlockedReason /><CardStored>false</CardStored><CardToken /></transactionresult></ProcessPurchaseByTokenResponse></soap:Body></soap:Envelope>
+    )
+  end
+
+  def failed_purchased_with_token_response
+    %(
+      <?xml version=\"1.0\" encoding=\"utf-8\"?><soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><soap:Body><soap:Fault><soap:Code><soap:Value>soap:Sender</soap:Value></soap:Code><soap:Reason><soap:Text xml:lang=\"en\">Card token not found</soap:Text></soap:Reason><soap:Node>ProcessTokenPayment</soap:Node><detail><error><errortype>Parameter</errortype><errornumber>2000</errornumber><errormessage>Card token not found</errormessage></error></detail></soap:Fault></soap:Body></soap:Envelope>
     )
   end
 end


### PR DESCRIPTION
Implements tokenisation for Flo2Cash. Adds support for `store`, `unstore` and tests for purchase with tokenised card.

Flo2Cash has two methods to tokenise, `AddCard` and `AddCardWithUniqueReference`, we implement both conditionally on the presence of `options[:order_id]`. The main difference between both is simply that one allows the unique reference to be associated to the token, which can then be used by the merchant to search for the token using that reference, the other just creates a simple token.

Refactor the `purchase` method to use the `ProcessPurchase` at the suggestion from support at Flo2Cash since most of their merchants are not using `ProcessAuthorise` (that's what I have been told).

Note: I am not entirely sure why the `purchase` was original set up as `auth` + `capture` so please feel free to comment on that.