### PR TITLE
Add support for payments using Charity Engine

### DIFF
--- a/lib/active_merchant/billing/gateways/charity_engine.rb
+++ b/lib/active_merchant/billing/gateways/charity_engine.rb
@@ -1,0 +1,226 @@
+require 'nokogiri'
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class CharityEngineGateway < Gateway
+      include Empty
+      URL = 'https://api.charityengine.net/api.asmx'
+
+      self.supported_countries = ['US']
+      self.default_currency = 'USD'
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover]
+
+      self.homepage_url = 'http://charityengine.net/'
+      self.display_name = 'Charity Engine'
+      self.money_format = :dollars
+
+      SOAP_ACTION_NS = 'https://api.bisglobal.net/'
+      SOAP_XMLNS = { xmlns: 'https://api.bisglobal.net/' }
+      NS = {
+        'xmlns:xsi'  => 'http://www.w3.org/2001/XMLSchema-instance',
+        'xmlns:xsd'  => 'http://www.w3.org/2001/XMLSchema',
+        'xmlns:soap12' => 'http://www.w3.org/2003/05/soap-envelope'
+      }
+
+      STANDARD_ERROR_CODE_MAPPING = {}
+
+      def initialize(options={})
+        requires!(options, :username, :password)
+        super
+      end
+
+      def purchase(money, payment_method, options={})
+        request = build_soap_request do |xml|
+          xml.ChargeCreditCard(SOAP_XMLNS) do
+            add_authentication(xml)
+            xml.parameters do
+              xml.Charges do
+                xml.ChargeCreditCardParameters do
+                  add_invoice(xml, money)
+                  add_billing_address(xml, options)
+                  add_credit_card(xml, payment_method)
+                  add_customer_details(xml, options) if options[:customer].present?
+                  add_attribution_details(xml, options) if options[:attribution].present?
+                end
+              end
+            end
+          end
+        end
+
+        commit('ChargeCreditCard', request)
+      end
+
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript.
+          gsub(%r((<Username>)[^<]*(</Username>))i, '\1[FILTERED]\2').
+          gsub(%r((<Password>)[^<]*(</Password>))i, '\1[FILTERED]\2').
+          gsub(%r((<CreditCardNumber>)[^<]*(</CreditCardNumber>))i, '\1[FILTERED]\2')
+      end
+
+      private
+
+      def add_address(xml, options={})
+        address = options[:billing_address] || options[:address]
+        if address.present?
+          xml.AddressStreet1 address[:address1] unless empty?(address[:address1])
+          xml.AddressStreet2 address[:address2] unless empty?(address[:address2])
+          xml.AddressCity address[:city] unless empty?(address[:city])
+          xml.AddressStateProvince address[:state] unless empty?(address[:state])
+          xml.AddressPostalCode address[:zip] unless empty?(address[:zip])
+        end
+      end
+
+      def add_billing_address(xml, options={})
+        billing_address = options[:billing_address] || options[:address]
+        if billing_address.present?
+          xml.CustomerBillingInfo do
+            xml.BillingAddressStreet1 billing_address[:address1] unless empty?(billing_address[:address1])
+            xml.BillingAddressStreet2 billing_address[:address2] unless empty?(billing_address[:address2])
+            xml.BillingAddressCity billing_address[:city] unless empty?(billing_address[:city])
+            xml.BillingAddressStateProvince billing_address[:state] unless empty?(billing_address[:state])
+            xml.BillingAddressPostalCode billing_address[:zip] unless empty?(billing_address[:zip])
+          end
+        end
+      end
+
+      def add_invoice(xml, money, options={})
+        xml.Amount amount(money)
+        xml.TaxDeductibleAmount amount(money)
+      end
+
+      def add_credit_card(xml, creditcard)
+        xml.CreditCardInfo do
+          xml.CreditCardNumber creditcard.number
+          xml.CreditCardExpirationMonth format(creditcard.month, :two_digits)
+          xml.CreditCardExpirationYear format(creditcard.year, :four_digits)
+          xml.CreditCardNameOnCard creditcard.name
+        end
+      end
+
+      def add_customer_details(xml, options={})
+        customer = options[:customer]
+        if customer.present?
+          xml.Contact do
+            xml.FirstName customer[:first_name]
+            xml.LastName customer[:last_name]
+            xml.PrimaryEmailAddress customer[:email]
+            xml.PrimaryPhone customer[:phone_number]
+            xml.BirthDate customer[:dob] unless empty?(customer[:dob])
+            xml.Gender customer[:gender] unless empty?(customer[:gender])
+            xml.ContactType 'Person'
+            add_address(xml, options)
+          end
+        end
+      end
+
+      def add_attribution_details(xml, options={})
+        attribution = options[:attribution]
+        if attribution.present?
+          xml.Attribution do
+            xml.ResponseChannel_Id attribution[:response_channel_id] unless empty?(attribution[:response_channel_id])
+            xml.Initiative_Id attribution[:initiative_id] unless empty?(attribution[:initiative_id])
+            xml.InitiativeSegment_Id attribution[:initiative_segment_id] unless empty?(attribution[:initiative_segment_id])
+          end
+        end
+      end
+
+      def parse(action, body)
+        parsed = {}
+
+        doc = Nokogiri::XML(body).remove_namespaces!
+        doc.xpath("//#{action}Response/#{action}Result/*").each do |node|
+          if (node.elements.empty?)
+            parsed[node.name.underscore.to_sym] = node.text
+          else
+            node.elements.each do |childnode|
+              name = "#{node.name}_#{childnode.name}"
+              # there's a deep-nest XML data structure that we want to extract
+              if name.underscore == "charges_transaction_detail"
+                childnode.elements.each do |grandchildnode|
+                  subname = "#{name}_#{grandchildnode.name}"
+                  parsed[subname.underscore.to_sym] = grandchildnode.text
+                end
+              else
+                # no deep nesting in the other elements or we don't care
+                parsed[name.underscore.to_sym] = childnode.text
+              end
+            end
+          end
+        end
+
+        parsed
+      end
+
+      def commit(action, xml)
+        response = parse(action, ssl_post(URL, xml, headers(action)))
+
+        Response.new(
+          success_from(response),
+          message_from(response),
+          response,
+          authorization: authorization_from(response),
+          test: test?,
+          error_code: error_code_from(response)
+        )
+      end
+
+      def add_authentication(xml)
+        xml.credentials do
+          xml.Username(@options[:username])
+          xml.Password(@options[:password])
+          xml.AuthenticationType 'WebServiceUser'
+        end
+      end
+
+      def headers(action)
+        {
+          'Content-Type'    => 'text/xml',
+          'SOAPAction'      => "#{SOAP_ACTION_NS}#{action}",
+        }
+      end
+
+      def build_soap_request
+        builder = Nokogiri::XML::Builder.new(encoding: 'UTF-8') do |xml|
+          xml['soap12'].Envelope(NS) do
+            xml['soap12'].Body do
+              yield(xml)
+            end
+          end
+        end
+
+        builder.to_xml
+      end
+
+      def success_from(response)
+        response[:successful] == 'true' && response[:error_message_code] == '0' && \
+        response[:charges_transaction_detail_payment_successful] == 'true'
+      end
+
+      def message_from(response)
+        if success_from(response)
+          # it's not clear if there's a message when there's a successful transaction
+        else
+          if response[:error_message_code] != '0'
+            "#{response[:error_message_code]} - #{response[:error_message_description]}"
+          else
+            response[:charges_transaction_detail_decline_details]
+          end
+        end
+      end
+
+      def authorization_from(response)
+        response[:charges_transaction_detail_transaction_id]
+      end
+
+      def error_code_from(response)
+        # we don't really seem to be getting errors from the API
+        # except if the call to the API itself failed, like 100 for invalid login
+        # but that's about it.
+      end
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -157,6 +157,10 @@ certo_direct:
   login: 1
   password: vP6OwK3
 
+charity_engine:
+  username: login
+  password: password
+
 checkout:
   merchant_id: SBMTEST
   password: Password1!

--- a/test/remote/gateways/remote_charity_engine_test.rb
+++ b/test/remote/gateways/remote_charity_engine_test.rb
@@ -1,0 +1,76 @@
+require 'test_helper'
+
+class RemoteCharityEngineTest < Test::Unit::TestCase
+  def setup
+    @gateway = CharityEngineGateway.new(fixtures(:charity_engine))
+
+    @amount = 100
+    @declined_amount = 1201
+    @credit_card = credit_card('370000000000002')
+    @declined_card = credit_card('4111111111111111', year: 2010)
+    @options = {
+      billing_address: address,
+      description: 'Store Purchase'
+    }
+  end
+
+  def test_successful_purchase
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+  end
+
+  def test_successful_purchase_with_more_options
+    options = {
+      order_id: '1',
+      ip: '127.0.0.1',
+      customer: {
+        email: 'joe@example.com',
+        dob: '1981-01-01',
+        first_name: 'Longbob',
+        last_name: 'Longsen',
+        gender: 'Male',
+        phone_number: address[:phone],
+      },
+      attribution: {
+        response_channel_id: '123',
+        initiative_id: '456',
+        initiative_segment_id: '789',
+      }
+    }
+
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+  end
+
+  def test_failed_purchase
+    response = @gateway.purchase(@amount, @declined_card, @options)
+    assert_failure response
+    assert_equal 'Expired Card', response.message
+  end
+
+  def test_declined_purchase
+    response = @gateway.purchase(@declined_amount, @credit_card, @options)
+    assert_failure response
+    assert_equal 'Declined', response.message
+  end
+
+  def test_invalid_login
+    gateway = CharityEngineGateway.new(username: '', password: '')
+
+    response = gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_match '100 - authentication failed', response.message
+  end
+
+  def test_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card.number, transcript)
+    assert_scrubbed(@gateway.options[:username], transcript)
+    assert_scrubbed(@gateway.options[:password], transcript)
+  end
+
+end

--- a/test/unit/gateways/charity_engine_test.rb
+++ b/test/unit/gateways/charity_engine_test.rb
@@ -1,0 +1,99 @@
+require 'test_helper'
+
+class CharityEngineTest < Test::Unit::TestCase
+  def setup
+    @gateway = CharityEngineGateway.new(username: 'login', password: 'password')
+    @credit_card = credit_card
+    @amount = 100
+
+    @options = {
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
+    }
+  end
+
+  def test_successful_purchase
+    @gateway.expects(:ssl_post).returns(successful_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+
+    assert_equal '42804774', response.authorization
+    assert response.test?
+  end
+
+  def test_failed_purchase
+    @gateway.expects(:ssl_post).returns(failed_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal 'Expired Card', response.message
+  end
+
+  def test_scrub
+    assert @gateway.supports_scrubbing?
+    assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
+  end
+
+  private
+
+  def pre_scrubbed
+    <<-XML
+opening connection to api.charityengine.net:443...
+opened
+starting SSL for api.charityengine.net:443...
+SSL established
+<- "POST /api.asmx HTTP/1.1\r\nContent-Type: text/xml\r\nSoapaction: https://api.bisglobal.net/ChargeCreditCard\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: api.charityengine.net\r\nContent-Length: 1476\r\n\r\n"
+<- "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soap12:Envelope xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:soap12=\"http://www.w3.org/2003/05/soap-envelope\">\n  <soap12:Body>\n    <ChargeCreditCard xmlns=\"https://api.bisglobal.net/\">\n      <credentials>\n        <Username>foo</Username>\n        <Password>bar</Password>\n        <AuthenticationType>WebServiceUser</AuthenticationType>\n      </credentials>\n      <parameters>\n        <Charges>\n          <ChargeCreditCardParameters>\n            <Amount>1.00</Amount>\n            <TaxDeductibleAmount>1.00</TaxDeductibleAmount>\n            <BillingAddressStreet1>456 My Street</BillingAddressStreet1>\n            <BillingAddressStreet2>Apt 1</BillingAddressStreet2>\n            <BillingAddressCity>Ottawa</BillingAddressCity>\n            <BillingAddressStateProvince>ON</BillingAddressStateProvince>\n            <BillingAddressPostalCode>K1C2N6</BillingAddressPostalCode>\n            <CreditCardInfo>\n              <CreditCardNumber>4000100011112224</CreditCardNumber>\n              <CreditCardExpirationMonth>09</CreditCardExpirationMonth>\n              <CreditCardExpirationYear>2018</CreditCardExpirationYear>\n              <CreditCardNameOnCard>Longbob Longsen</CreditCardNameOnCard>\n            </CreditCardInfo>\n          </ChargeCreditCardParameters>\n        </Charges>\n      </parameters>\n    </ChargeCreditCard>\n  </soap12:Body>\n</soap12:Envelope>\n"
+-> "HTTP/1.1 200 OK\r\n"
+-> "Cache-Control: private, max-age=0\r\n"
+-> "Content-Type: application/soap+xml; charset=utf-8\r\n"
+-> "Server: Microsoft-IIS/8.5\r\n"
+-> "X-AspNet-Version: 4.0.30319\r\n"
+-> "X-Powered-By: ASP.NET\r\n"
+-> "Date: Mon, 27 Mar 2017 00:10:38 GMT\r\n"
+-> "Connection: close\r\n"
+-> "Content-Length: 1375\r\n"
+-> "\r\n"
+reading 1375 bytes...
+-> "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\r\n  <soap:Body>\r\n    <ChargeCreditCardResponse xmlns=\"https://api.bisglobal.net/\">\r\n      <ChargeCreditCardResult>\r\n        <Successful>true</Successful>\r\n        <Record_Id>0</Record_Id>\r\n        <RecordIdList>\r\n          <long>42782466</long>\r\n        </RecordIdList>\r\n        <ErrorMessage>\r\n          <Code>0</Code>\r\n          <Description />\r\n        </ErrorMessage>\r\n        <QueryRecordCount>0</QueryRecordCount>\r\n        <RecordsAffected>1</RecordsAffected>\r\n        <Charges>\r\n          <TransactionDetail>\r\n            <Successful>true</Successful>\r\n            <Record_Id>0</Record_Id>\r\n            <RecordIdList />\r\n            <ErrorMessage>\r\n              <Code>0</Code>\r\n              <Description />\r\n            </ErrorMessage>\r\n            <QueryRecordCount>0</QueryRecordCount>\r\n            <RecordsAffected>0</RecordsAffected>\r\n            <Transaction_Id>42782466</Transaction_Id>\r\n            <PaymentSuccessful>false</PaymentSuccessful>\r\n            <DeclineDetails>Declined</DeclineDetails>\r\n          </TransactionDetail>\r\n        </Charges>\r\n      </ChargeCreditCardResult>\r\n    </ChargeCreditCardResponse>\r\n  </soap:Body>\r\n</soap:Envelope>\r\n"
+read 1375 bytes
+Conn close
+    XML
+  end
+
+  def post_scrubbed
+    <<-XML
+opening connection to api.charityengine.net:443...
+opened
+starting SSL for api.charityengine.net:443...
+SSL established
+<- "POST /api.asmx HTTP/1.1\r\nContent-Type: text/xml\r\nSoapaction: https://api.bisglobal.net/ChargeCreditCard\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: api.charityengine.net\r\nContent-Length: 1476\r\n\r\n"
+<- "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soap12:Envelope xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:soap12=\"http://www.w3.org/2003/05/soap-envelope\">\n  <soap12:Body>\n    <ChargeCreditCard xmlns=\"https://api.bisglobal.net/\">\n      <credentials>\n        <Username>[FILTERED]</Username>\n        <Password>[FILTERED]</Password>\n        <AuthenticationType>WebServiceUser</AuthenticationType>\n      </credentials>\n      <parameters>\n        <Charges>\n          <ChargeCreditCardParameters>\n            <Amount>1.00</Amount>\n            <TaxDeductibleAmount>1.00</TaxDeductibleAmount>\n            <BillingAddressStreet1>456 My Street</BillingAddressStreet1>\n            <BillingAddressStreet2>Apt 1</BillingAddressStreet2>\n            <BillingAddressCity>Ottawa</BillingAddressCity>\n            <BillingAddressStateProvince>ON</BillingAddressStateProvince>\n            <BillingAddressPostalCode>K1C2N6</BillingAddressPostalCode>\n            <CreditCardInfo>\n              <CreditCardNumber>[FILTERED]</CreditCardNumber>\n              <CreditCardExpirationMonth>09</CreditCardExpirationMonth>\n              <CreditCardExpirationYear>2018</CreditCardExpirationYear>\n              <CreditCardNameOnCard>Longbob Longsen</CreditCardNameOnCard>\n            </CreditCardInfo>\n          </ChargeCreditCardParameters>\n        </Charges>\n      </parameters>\n    </ChargeCreditCard>\n  </soap12:Body>\n</soap12:Envelope>\n"
+-> "HTTP/1.1 200 OK\r\n"
+-> "Cache-Control: private, max-age=0\r\n"
+-> "Content-Type: application/soap+xml; charset=utf-8\r\n"
+-> "Server: Microsoft-IIS/8.5\r\n"
+-> "X-AspNet-Version: 4.0.30319\r\n"
+-> "X-Powered-By: ASP.NET\r\n"
+-> "Date: Mon, 27 Mar 2017 00:10:38 GMT\r\n"
+-> "Connection: close\r\n"
+-> "Content-Length: 1375\r\n"
+-> "\r\n"
+reading 1375 bytes...
+-> "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\r\n  <soap:Body>\r\n    <ChargeCreditCardResponse xmlns=\"https://api.bisglobal.net/\">\r\n      <ChargeCreditCardResult>\r\n        <Successful>true</Successful>\r\n        <Record_Id>0</Record_Id>\r\n        <RecordIdList>\r\n          <long>42782466</long>\r\n        </RecordIdList>\r\n        <ErrorMessage>\r\n          <Code>0</Code>\r\n          <Description />\r\n        </ErrorMessage>\r\n        <QueryRecordCount>0</QueryRecordCount>\r\n        <RecordsAffected>1</RecordsAffected>\r\n        <Charges>\r\n          <TransactionDetail>\r\n            <Successful>true</Successful>\r\n            <Record_Id>0</Record_Id>\r\n            <RecordIdList />\r\n            <ErrorMessage>\r\n              <Code>0</Code>\r\n              <Description />\r\n            </ErrorMessage>\r\n            <QueryRecordCount>0</QueryRecordCount>\r\n            <RecordsAffected>0</RecordsAffected>\r\n            <Transaction_Id>42782466</Transaction_Id>\r\n            <PaymentSuccessful>false</PaymentSuccessful>\r\n            <DeclineDetails>Declined</DeclineDetails>\r\n          </TransactionDetail>\r\n        </Charges>\r\n      </ChargeCreditCardResult>\r\n    </ChargeCreditCardResponse>\r\n  </soap:Body>\r\n</soap:Envelope>\r\n"
+read 1375 bytes
+Conn close
+    XML
+  end
+
+  def successful_purchase_response
+    %(<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\r\n  <soap:Body>\r\n    <ChargeCreditCardResponse xmlns=\"https://api.bisglobal.net/\">\r\n      <ChargeCreditCardResult>\r\n        <Successful>true</Successful>\r\n        <Record_Id>0</Record_Id>\r\n        <RecordIdList>\r\n          <long>42804774</long>\r\n        </RecordIdList>\r\n        <ErrorMessage>\r\n          <Code>0</Code>\r\n          <Description />\r\n        </ErrorMessage>\r\n        <QueryRecordCount>0</QueryRecordCount>\r\n        <RecordsAffected>1</RecordsAffected>\r\n        <Charges>\r\n          <TransactionDetail>\r\n            <Successful>true</Successful>\r\n            <Record_Id>0</Record_Id>\r\n            <RecordIdList />\r\n            <ErrorMessage>\r\n              <Code>0</Code>\r\n              <Description />\r\n            </ErrorMessage>\r\n            <QueryRecordCount>0</QueryRecordCount>\r\n            <RecordsAffected>0</RecordsAffected>\r\n            <Transaction_Id>42804774</Transaction_Id>\r\n            <PaymentSuccessful>true</PaymentSuccessful>\r\n            <DeclineDetails />\r\n          </TransactionDetail>\r\n        </Charges>\r\n      </ChargeCreditCardResult>\r\n    </ChargeCreditCardResponse>\r\n  </soap:Body>\r\n</soap:Envelope>\r\n)
+  end
+
+  def failed_purchase_response
+    %(<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\r\n  <soap:Body>\r\n    <ChargeCreditCardResponse xmlns=\"https://api.bisglobal.net/\">\r\n      <ChargeCreditCardResult>\r\n        <Successful>true</Successful>\r\n        <Record_Id>0</Record_Id>\r\n        <RecordIdList>\r\n          <long>42798609</long>\r\n        </RecordIdList>\r\n        <ErrorMessage>\r\n          <Code>0</Code>\r\n          <Description />\r\n        </ErrorMessage>\r\n        <QueryRecordCount>0</QueryRecordCount>\r\n        <RecordsAffected>1</RecordsAffected>\r\n        <Charges>\r\n          <TransactionDetail>\r\n            <Successful>true</Successful>\r\n            <Record_Id>0</Record_Id>\r\n            <RecordIdList />\r\n            <ErrorMessage>\r\n              <Code>0</Code>\r\n              <Description />\r\n            </ErrorMessage>\r\n            <QueryRecordCount>0</QueryRecordCount>\r\n            <RecordsAffected>0</RecordsAffected>\r\n            <Transaction_Id>42798609</Transaction_Id>\r\n            <PaymentSuccessful>false</PaymentSuccessful>\r\n            <DeclineDetails>Expired Card</DeclineDetails>\r\n          </TransactionDetail>\r\n        </Charges>\r\n      </ChargeCreditCardResult>\r\n    </ChargeCreditCardResponse>\r\n  </soap:Body>\r\n</soap:Envelope>\r\n)
+  end
+
+end


### PR DESCRIPTION
Implement a very basic gateway, with only support for `purchase` for
Charity Engine. Charity Engine is more a CRM than it is a gateway, they
use Authorize.net upstream.

Several parameters can be passed optionally, like the whole structure
in the `options[:customer]` or `options[:attribution]` (see the remote
gateway test for samples) that will be passed on to CE.

This is not a proper ActiveMerchant gateway implementation, thus I am not sending it upstream, only to `waysact/master`.