### PR TITLE
Add support for tracking codes within attribution

### DIFF
--- a/lib/active_merchant/billing/gateways/charity_engine.rb
+++ b/lib/active_merchant/billing/gateways/charity_engine.rb
@@ -124,6 +124,20 @@ module ActiveMerchant #:nodoc:
             xml.ResponseChannel_Id attribution[:response_channel_id] unless empty?(attribution[:response_channel_id])
             xml.Initiative_Id attribution[:initiative_id] unless empty?(attribution[:initiative_id])
             xml.InitiativeSegment_Id attribution[:initiative_segment_id] unless empty?(attribution[:initiative_segment_id])
+            add_tracking_codes(xml, attribution[:tracking_codes]) unless empty?(attribution[:tracking_codes])
+          end
+        end
+      end
+
+      # tracking codes are expected in the `attribution[:tracking_codes]` datastructure
+      # as `code1: '123', code2: 'foo' ... `
+      def add_tracking_codes(xml, options={})
+        we_have_at_least_one_code = false
+        (1..8).each { |i| we_have_at_least_one_code = true if options.key?("code#{i}".to_sym) }
+        return unless we_have_at_least_one_code
+        xml.TrackingCodes do
+          (1..8).each do |counter|
+            xml.send("Code#{counter}", options["code#{counter}".to_sym]) unless empty?(options["code#{counter}".to_sym])
           end
         end
       end

--- a/test/remote/gateways/remote_charity_engine_test.rb
+++ b/test/remote/gateways/remote_charity_engine_test.rb
@@ -35,6 +35,10 @@ class RemoteCharityEngineTest < Test::Unit::TestCase
         response_channel_id: '123',
         initiative_id: '456',
         initiative_segment_id: '789',
+        tracking_codes: {
+          code4: SecureRandom.uuid,
+          code5: 'Foo Bar'
+        }
       }
     }
 


### PR DESCRIPTION
This change adds support for optional fields (`code1` to `code8`) that
can be passed in the `attribution` data structure in a `tracking_codes:
{}` hash, example:

```
attribution: {
  response_channel_id: ‘123’,
  tracking_codes: {
    code3: ‘some value’,
    code6: ‘another value’
  },
}
```