### PR TITLE
Add support for purchases using ephemeral tokens

### DIFF
--- a/test/remote/gateways/remote_openpay_test.rb
+++ b/test/remote/gateways/remote_openpay_test.rb
@@ -20,6 +20,7 @@ class RemoteOpenpayTest < Test::Unit::TestCase
         phone: address[:phone]
       },
       email: 'longsen@example.com',
+      use_token: true
     }
   end
 
@@ -30,7 +31,7 @@ class RemoteOpenpayTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_token
-    assert response = @gateway.purchase_with_token(@amount, @credit_card, @options.merge(@additional_options))
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(@additional_options))
     assert_success response
     assert_nil response.message
   end

--- a/test/remote/gateways/remote_openpay_test.rb
+++ b/test/remote/gateways/remote_openpay_test.rb
@@ -13,10 +13,24 @@ class RemoteOpenpayTest < Test::Unit::TestCase
       billing_address: address,
       description: 'Store Purchase'
     }
+    @additional_options = {
+      customer: {
+        first_name: 'Longbob',
+        last_name: 'Longsen',
+        phone: address[:phone]
+      },
+      email: 'longsen@example.com',
+    }
   end
 
   def test_successful_purchase
     assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_nil response.message
+  end
+
+  def test_successful_purchase_with_token
+    assert response = @gateway.purchase_with_token(@amount, @credit_card, @options.merge(@additional_options))
     assert_success response
     assert_nil response.message
   end

--- a/test/unit/gateways/openpay_test.rb
+++ b/test/unit/gateways/openpay_test.rb
@@ -198,8 +198,9 @@ class OpenpayTest < Test::Unit::TestCase
     @gateway.expects(:ssl_request).twice.returns(successful_new_token, successful_new_charge)
     @options[:customer] = { first_name: 'Longbob', last_name: 'Longsen', phone: address[:phone] }
     @options[:email] = 'longsen@example.com'
+    @options[:use_token] = true
 
-    assert response = @gateway.purchase_with_token(@amount, @credit_card, @options)
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_instance_of MultiResponse, response
     assert_success response
     assert_equal 2, response.responses.size

--- a/test/unit/gateways/openpay_test.rb
+++ b/test/unit/gateways/openpay_test.rb
@@ -194,6 +194,26 @@ class OpenpayTest < Test::Unit::TestCase
     assert_equal whitespace_string_cvv_scrubbed_transcript, @gateway.scrub(whitespace_string_cvv_transcript)
   end
 
+  def test_successful_purchase_with_token
+    @gateway.expects(:ssl_request).twice.returns(successful_new_token, successful_new_charge)
+    @options[:customer] = { first_name: 'Longbob', last_name: 'Longsen', phone: address[:phone] }
+    @options[:email] = 'longsen@example.com'
+
+    assert response = @gateway.purchase_with_token(@amount, @credit_card, @options)
+    assert_instance_of MultiResponse, response
+    assert_success response
+    assert_equal 2, response.responses.size
+
+    token_response = response.responses[0]
+    assert_not_nil token_response.params['id']
+
+    charge_response = response.responses[1]
+    assert_not_nil charge_response.params['id']
+
+    assert response.test?
+  end
+
+
   private
 
   def successful_new_card
@@ -605,5 +625,86 @@ class OpenpayTest < Test::Unit::TestCase
       }
     }
     SCRUBBED_TRANSCRIPT
+  end
+
+  def successful_new_token
+    <<-RESPONSE
+{
+  "id": "k1tlvljbs1iqv64txu4r",
+  "card": {
+    "card_number": "411111XXXXXX1111",
+    "holder_name": "Longbob Longsen",
+    "expiration_year": "18",
+    "expiration_month": "09",
+    "address": {
+      "line1": "456 My Street",
+      "line2": "Apt 1",
+      "line3": "Widgets Inc",
+      "state": "ON",
+      "city": "Ottawa",
+      "postal_code": "K1C2N6",
+      "country_code": "CA"
+    },
+    "creation_date": null,
+    "brand": "visa"
+  }
+}
+    RESPONSE
+  end
+
+  def successful_new_charge
+    <<-RESPONSE
+{
+  "id": "trntzfavar7amwi8mht1",
+  "authorization": "801585",
+  "operation_type": "in",
+  "method": "card",
+  "transaction_type": "charge",
+  "card": {
+    "type": "debit",
+    "brand": "visa",
+    "address": {
+      "line1": "456 My Street",
+      "line2": "Apt 1",
+      "line3": "Widgets Inc",
+      "state": "ON",
+      "city": "Ottawa",
+      "postal_code": "K1C2N6",
+      "country_code": "CA"
+    },
+    "card_number": "411111XXXXXX1111",
+    "holder_name": "Longbob Longsen",
+    "expiration_year": "18",
+    "expiration_month": "09",
+    "allows_charges": true,
+    "allows_payouts": true,
+    "bank_name": "Banamex",
+    "bank_code": "002"
+  },
+  "status": "completed",
+  "conciliated": false,
+  "creation_date": "2017-04-11T23:52:15-05:00",
+  "operation_date": "2017-04-11T23:52:15-05:00",
+  "description": "Store Purchase",
+  "error_message": null,
+  "order_id": null,
+  "fee": {
+    "amount": 2.53,
+    "tax": 0.4048
+  },
+  "amount": 1,
+  "customer": {
+    "name": "Longbob",
+    "last_name": "Longsen",
+    "email": "longsen@example.com",
+    "phone_number": "(555)555-5555",
+    "address": null,
+    "creation_date": "2017-04-11T23:52:15-05:00",
+    "external_id": null,
+    "clabe": null
+  },
+  "currency": "MXN"
+}
+    RESPONSE
   end
 end


### PR DESCRIPTION
One of our customers Openpay account is configured (can’t find the proper reason from their support as to why) to use the “comercio” configuration and thus we need to use the ephemeral “token” (mandatory) prior to calling the charges API.

I extended the `purchase` method to now allow the multi-step call to create a `token` and use the resulting `id` as the `source_id` for the `charges` if the `options[:use_token]` is present with any value.

This is a bit of a hack, however that way we can call the `charges` endpoint or do the workflow depending on the customer's account configuration.