### PR TITLE
Scrub login and update URLs for payment express

### DIFF
--- a/lib/active_merchant/billing/gateways/payment_express.rb
+++ b/lib/active_merchant/billing/gateways/payment_express.rb
@@ -21,7 +21,8 @@ module ActiveMerchant #:nodoc:
       self.homepage_url = 'http://www.paymentexpress.com/'
       self.display_name = 'PaymentExpress'
 
-      self.live_url = self.test_url = 'https://sec.paymentexpress.com/pxpost.aspx'
+      self.live_url = 'https://sec.paymentexpress.com/pxpost.aspx'
+      self.test_url = 'https://uat.paymentexpress.com/pxpost.aspx'
 
       APPROVED = '1'
 
@@ -130,7 +131,9 @@ module ActiveMerchant #:nodoc:
         transcript.
           gsub(%r((Authorization: Basic )\w+), '\1[FILTERED]').
           gsub(%r((<CardNumber>)\d+(</CardNumber>)), '\1[FILTERED]\2').
-          gsub(%r((<Cvc2>)\d+(</Cvc2>)), '\1[FILTERED]\2')
+          gsub(%r((<Cvc2>)\d+(</Cvc2>)), '\1[FILTERED]\2').
+          gsub(%r((<PostUsername>)\w+(</PostUsername>)), '\1[FILTERED]\2').
+          gsub(%r((<PostPassword>)\w+(</PostPassword>)), '\1[FILTERED]\2')
       end
 
       private
@@ -293,7 +296,7 @@ module ActiveMerchant #:nodoc:
         add_transaction_type(request, action)
 
         # Parse the XML response
-        response = parse( ssl_post(self.live_url, request.to_s) )
+        response = parse( ssl_post(url, request.to_s) )
 
         # Return a response
         PaymentExpressResponse.new(response[:success] == APPROVED, message_from(response), response,
@@ -321,6 +324,10 @@ module ActiveMerchant #:nodoc:
         end
 
         response
+      end
+
+      def url
+        test? ? test_url : live_url
       end
 
       def message_from(response)

--- a/test/remote/gateways/remote_payment_express_test.rb
+++ b/test/remote/gateways/remote_payment_express_test.rb
@@ -5,7 +5,10 @@ class RemotePaymentExpressTest < Test::Unit::TestCase
   def setup
     @gateway = PaymentExpressGateway.new(fixtures(:payment_express))
 
-    @credit_card = credit_card('4111111111111111')
+    # the cvv assertion in the scrubbing test fails most of the time as
+    # the default of 123 is usually found in other parts of the transcript
+    # so use a less common occurence of 432 (weird)
+    @credit_card = credit_card('4111111111111111', {verification_value: 432})
 
     @options = {
       :order_id => generate_unique_id,
@@ -75,7 +78,7 @@ class RemotePaymentExpressTest < Test::Unit::TestCase
       :password => ''
     )
     assert response = gateway.purchase(@amount, @credit_card, @options)
-    assert_match %r{error}i, response.message
+    assert_match %r{invalid credentials}i, response.message
     assert_failure response
   end
 
@@ -138,6 +141,8 @@ class RemotePaymentExpressTest < Test::Unit::TestCase
 
     assert_scrubbed(@credit_card.number, clean_transcript)
     assert_scrubbed(@credit_card.verification_value.to_s, clean_transcript)
+    assert_scrubbed(fixtures(:payment_express)[:login], clean_transcript)
+    assert_scrubbed(fixtures(:payment_express)[:password], clean_transcript)
   end
 
 end


### PR DESCRIPTION
Payment Express required us to use uat.paymentexpress.com instead of
the sec.paymentexpress.com which is documented in their PxPost docs and
the default active merchant implementation.

Also add the login details to the transcript scrubbing to ensure we
don’t leak sensitive information.

In the remote tests, update the error we receive with invalid
credentials, use a non-default CVV for the tests, in particular this is
relevant for the scrubbing tests, as 432 doesn’t seem to occur
regularly and thus doesn’t trigger a false failure. Also add tests for
the login and password.