### PR TITLE
Use Tokenize TxnType for tokenisation

### DIFF
--- a/lib/active_merchant/billing/gateways/payment_express.rb
+++ b/lib/active_merchant/billing/gateways/payment_express.rb
@@ -30,7 +30,8 @@ module ActiveMerchant #:nodoc:
         :credit         => 'Refund',
         :authorization  => 'Auth',
         :capture        => 'Complete',
-        :validate       => 'Validate'
+        :validate       => 'Validate',
+        :tokenize       => 'Tokenize'
       }
 
       # We require the DPS gateway username and password when the object is created.
@@ -119,7 +120,7 @@ module ActiveMerchant #:nodoc:
       # Note, once stored, PaymentExpress does not support unstoring a stored card.
       def store(credit_card, options = {})
         request  = build_token_request(credit_card, options)
-        commit(:validate, request)
+        commit(:tokenize, request)
       end
 
       def supports_scrubbing
@@ -329,7 +330,7 @@ module ActiveMerchant #:nodoc:
 
       def authorization_from(action, response)
         case action
-        when :validate
+        when :validate, :tokenize
           (response[:billing_id] || response[:dps_billing_id])
         else
           response[:dps_txn_ref]


### PR DESCRIPTION
As recommended by the Payment Express support team, we need to pass
`<TxnType>Tokenize</TxnType>` instead of `<TxnType>Validate</TxnType>`
for `store`. Note: this `TxnType` is not on their documentation however
I have been told, upon specific question, that this is valid and can be
used.