### PR TITLE
:bug: Use OpenSSL CA bundle instead of AM's

### DIFF
--- a/lib/active_merchant/connection.rb
+++ b/lib/active_merchant/connection.rb
@@ -119,8 +119,10 @@ module ActiveMerchant
 
       if verify_peer
         http.verify_mode = OpenSSL::SSL::VERIFY_PEER
-        http.ca_file     = ca_file
-        http.ca_path     = ca_path
+        # Use OpenSSL's own certificate store instead of ActiveMerchant's
+        # from dxw/active_merchant#2
+        # http.ca_file     = ca_file
+        # http.ca_path     = ca_path
       else
         http.verify_mode = OpenSSL::SSL::VERIFY_NONE
       end


### PR DESCRIPTION
Rather than using ActiveMerchant's outdated CA certificates, use the
system ones. This resolves issues with Merchant First.

This was based on a suggestion found in a Github issue here:
activemerchant#1643 (comment) and
https://github.com/dxw/active_merchant/pull/2