### PR TITLE
Send different element for card details for store

### DIFF
--- a/lib/active_merchant/billing/gateways/flo2cash.rb
+++ b/lib/active_merchant/billing/gateways/flo2cash.rb
@@ -68,7 +68,7 @@ module ActiveMerchant #:nodoc:
 
       def store(payment_method, options={})
         post = {}
-        add_payment_method(post, payment_method)
+        add_payment_method(post, payment_method, true)
         if options[:order_id].present?
           add_unique_reference(post, options[:order_id])
           action = 'AddCardWithUniqueReference'
@@ -108,11 +108,13 @@ module ActiveMerchant #:nodoc:
         post[:Particular] = options[:description]
       end
 
-      def add_payment_method(post, payment_method)
+      def add_payment_method(post, payment_method, store_action = false)
         post[:CardNumber] = payment_method.number
         post[:CardType] = BRAND_MAP[payment_method.brand.to_s]
         post[:CardExpiry] = format(payment_method.month, :two_digits) + format(payment_method.year, :two_digits)
-        post[:CardHolderName] = payment_method.name
+        # the tokenisation method needs CardName instead of CardHolderName
+        card_holder_name_elem = store_action ? :CardName : :CardHolderName
+        post[card_holder_name_elem] = payment_method.name
         post[:CardCSC] = payment_method.verification_value if payment_method.verification_value
       end
 

--- a/test/remote/gateways/remote_flo2cash_test.rb
+++ b/test/remote/gateways/remote_flo2cash_test.rb
@@ -8,7 +8,7 @@ class RemoteFlo2cashTest < Test::Unit::TestCase
 
     @amount = 100
     @declined_amount = 110
-    @credit_card = credit_card('5123456789012346', brand: :master, month: 5, year: 2017, verification_value: 111)
+    @credit_card = credit_card('5123456789012346', brand: :master, month: 5, year: 2020, verification_value: 111)
     @declined_card = credit_card('4000300011112220')
 
     @options = {


### PR DESCRIPTION
Flo2Cash’s documentation shows that tokenisation requires the card holder name to be passed in an element named `CardName` instead of the default `CardHolderName` which is used for other methods. I added a simple boolean flag to the `add_payment_method` that default to `false` as the simplest fix.

And also added the expiry of the remote test card into the future.