### PR TITLE
Nokogiri option to output XML without indentation

### DIFF
--- a/lib/active_merchant/billing/gateways/payment_solutions.rb
+++ b/lib/active_merchant/billing/gateways/payment_solutions.rb
@@ -205,7 +205,7 @@ module ActiveMerchant #:nodoc:
           end
         end
 
-        builder.to_xml
+        builder.to_xml(save_with: Nokogiri::XML::Node::SaveOptions::AS_XML)
       end
 
       def add_authentication(xml, options={})


### PR DESCRIPTION
Use an output Nokogiri option to generate the XML without indentation (remove extra carriage returns and whitespace).

See https://stackoverflow.com/questions/8406251/nokogiri-to-xml-without-carriage-returns