### PR TITLE
Re-order XML attributes for customer data in PSI

### DIFF
--- a/lib/active_merchant/billing/gateways/payment_solutions.rb
+++ b/lib/active_merchant/billing/gateways/payment_solutions.rb
@@ -89,7 +89,9 @@ module ActiveMerchant #:nodoc:
         xml['d4p1'].Donor do
           address = options[:billing_address] || options[:address]
           xml['d4p1'].Address1 address[:address1] if address[:address1]
+          xml['d4p1'].Address2 address[:address2] if address[:address2]
           xml['d4p1'].City address[:city] if address[:city]
+          xml['d4p1'].Email address[:email] if address[:email]
           xml['d4p1'].Employer nil
           xml['d4p1'].FirstName payment.first_name
           xml['d4p1'].LastName payment.last_name
@@ -97,9 +99,7 @@ module ActiveMerchant #:nodoc:
           xml['d4p1'].PostalCode address[:zip] if address[:zip]
           xml['d4p1'].SendEmail address[:email].present?
           xml['d4p1'].StateProvince address[:state] if address[:state]
-          xml['d4p1'].Address2 address[:address2] if address[:address2]
           xml['d4p1'].Country address[:country] if address[:country]
-          xml['d4p1'].Email address[:email] if address[:email]
         end
       end
 


### PR DESCRIPTION
As required by PSI, the XML attributes in the sequence should be added in a specific order.