### PR TITLE
SendEmail is false unless explicitly set otherwise

### DIFF
--- a/lib/active_merchant/billing/gateways/payment_solutions.rb
+++ b/lib/active_merchant/billing/gateways/payment_solutions.rb
@@ -95,7 +95,7 @@ module ActiveMerchant #:nodoc:
           xml['d4p1'].LastName payment.last_name
           xml['d4p1'].Phone address[:phone] if address[:phone]
           xml['d4p1'].PostalCode address[:zip] if address[:zip]
-          xml['d4p1'].SendEmail address[:email].present?
+          xml['d4p1'].SendEmail empty?(options[:send_email].present?) ? false : options[:send_email]
           xml['d4p1'].StateProvince address[:state] if address[:state]
           xml['d4p1'].Address2 address[:address2] if address[:address2]
           xml['d4p1'].Country address[:country] if address[:country]


### PR DESCRIPTION
The SendEmail attribute needs to be set to `false` based on another attribute that’s no longer just the presence or absence of `address[:email]` … the attribute we’ll be passing is `options[:send_email]` and it’ll be a boolean … so if it’s absent we default to `false`.