### PR TITLE
Add support for Blackbaud BBPS

### DIFF
--- a/lib/active_merchant/billing/gateways/blackbaud_bbps.rb
+++ b/lib/active_merchant/billing/gateways/blackbaud_bbps.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+require 'nokogiri'
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class BlackbaudBbpsGateway < Gateway
+      self.supported_countries = ['US']
+      self.default_currency = 'USD'
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover]
+
+      self.homepage_url = 'http://www.blackbaud.com/'
+      self.display_name = 'Blackbaud BBPS'
+
+      ENV_NS = {
+        'xmlns:xsi'     => 'http://www.w3.org/2001/XMLSchema-instance',
+        'xmlns:xsd'     => 'http://www.w3.org/2001/XMLSchema',
+        'xmlns:soap12'  => 'http://www.w3.org/2003/05/soap-envelope'
+      }.freeze
+      SOAP_ACTION_NS = 'Blackbaud.AppFx.WebService.API.1'
+      SOAP_XMLNS = { xmlns: SOAP_ACTION_NS }.freeze
+
+      def initialize(options = {})
+        requires!(options, :hostname, :username, :password)
+        super
+      end
+
+      def store(credit_card, options = {})
+        request = build_soap_request do |xml|
+          xml.CreditCardVaultRequest(SOAP_XMLNS) do
+            add_client_app(xml, options)
+            add_payment(xml, credit_card)
+          end
+        end
+
+        commit('CreditCardVault', request)
+      end
+
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript.
+          gsub(%r((Authorization: Basic )\w+), '\1[FILTERED]').
+          gsub(%r((<CardNumber>).+(</CardNumber>))i, '\1[FILTERED]\2')
+      end
+
+      private
+
+      def client_app(options = {})
+        options[:client_app] || 'Evergiving'
+      end
+
+      def database_to_use(options = {})
+        options[:database_to_use] || 'BBInfinity'
+      end
+
+      def add_client_app(xml, options)
+        xml.ClientAppInfo(
+          REDatabaseToUse: database_to_use(options),
+          ClientAppName: client_app(options),
+          xmlns: SOAP_ACTION_NS
+        )
+      end
+
+      def add_payment(xml, payment)
+        xml.CreditCards do
+          xml.CreditCardInfo do
+            xml.CardHolder payment.name
+            xml.CardNumber payment.number
+            xml.ExpirationDate do
+              xml.Month format(payment.month, :two_digits)
+              xml.Year format(payment.year, :four_digits)
+            end
+          end
+        end
+      end
+
+      def parse(action, body)
+        parsed = {}
+
+        doc = Nokogiri::XML(body).remove_namespaces!
+        doc.xpath("//#{action}Response/*").each do |node|
+          if (node.elements.empty?)
+            parsed[node.name.underscore.to_sym] = node.text
+          else
+            node.elements.each do |childnode|
+              name = "#{node.name}_#{childnode.name}"
+              parsed[name.underscore.to_sym] = childnode.text
+            end
+          end
+        end
+
+        parsed
+      end
+
+      def basic_auth
+        Base64.strict_encode64("#{@options[:username]}:#{@options[:password]}")
+      end
+
+      def headers(action)
+        {
+          'Content-Type'    => 'text/xml; charset=utf-8',
+          'Host'            => @options[:hostname],
+          'SOAPAction'      => "#{SOAP_ACTION_NS}/#{action}",
+          'Authorization'   => "Basic #{basic_auth}"
+        }
+      end
+
+      def url
+        "https://#{@options[:hostname].strip}/bbAppFx/AppFxWebService.asmx"
+      end
+
+      def commit(action, xml)
+        response = parse(action, ssl_post(url, xml, headers(action)))
+
+        Response.new(
+          success_from(action, response),
+          message_from(action, response),
+          response,
+          authorization: authorization_from(action, response),
+          test: test?
+        )
+      end
+
+      def build_soap_request
+        builder = Nokogiri::XML::Builder.new(encoding: 'UTF-8') do |xml|
+          xml['soap12'].Envelope(ENV_NS) do
+            xml['soap12'].Body do
+              yield(xml)
+            end
+          end
+        end
+
+        builder.to_xml(save_with: Nokogiri::XML::Node::SaveOptions::AS_XML)
+      end
+
+      def success_from(_action, response)
+        response[:status] == 'Success'
+      end
+
+      def message_from(action, response)
+        if success_from(action, response)
+          response[:status]
+        else
+          response[:error_message]
+        end
+      end
+
+      def authorization_from(_action, response)
+        response[:token]
+      end
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -76,6 +76,11 @@ beanstream_interac:
 bit_pay:
   api_key: 'rKrahSl7WRrYeKRUhGzbvW3nBzo0jG4FPaL8uPYaoPk'
 
+blackbaud_bbps:
+  hostname: hostname_from_blackbaud
+  username: username
+  password: password
+
 blue_pay:
   login: '100096218902'
   password: 'MBUVE4G1BACMFM4W3XQHUUL2SMQRP.LW'

--- a/test/remote/gateways/remote_blackbaud_bbps_test.rb
+++ b/test/remote/gateways/remote_blackbaud_bbps_test.rb
@@ -1,0 +1,44 @@
+require 'test_helper'
+
+class RemoteBlackbaudBbpsTest < Test::Unit::TestCase
+  def setup
+    @gateway = BlackbaudBbpsGateway.new(fixtures(:blackbaud_bbps))
+
+    @amount = 100
+    @credit_card = credit_card('4000100011112224')
+    @declined_card = credit_card('1111111111111111')
+    @options = {
+      client_app: 'Evergiving Test'
+    }
+  end
+
+  def test_successful_store
+    response = @gateway.store(@credit_card, @options)
+    assert_success response
+    assert_match %r{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}}, response.authorization
+  end
+
+  def test_success_store_without_options
+    response = @gateway.store(@credit_card)
+    assert_success response
+    assert_match %r{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}}, response.authorization
+  end
+
+  def test_failed_store
+    response = @gateway.store(@declined_card, @options)
+    assert_failure response
+    assert_match 'Credit card number is not valid.', response.message
+  end
+
+  def test_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.store(@credit_card, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card.number, transcript)
+    basic_auth = Base64.strict_encode64("#{@options[:username]}:#{@options[:password]}")
+    assert_scrubbed(basic_auth, transcript)
+  end
+
+end

--- a/test/unit/gateways/blackbaud_bbps_test.rb
+++ b/test/unit/gateways/blackbaud_bbps_test.rb
@@ -1,0 +1,96 @@
+require 'test_helper'
+
+class BlackbaudBbpsTest < Test::Unit::TestCase
+  def setup
+    @gateway = BlackbaudBbpsGateway.new(hostname: 'foo', username: 'bar', password: 'sekrit')
+    @credit_card = credit_card
+
+    @options = {
+      client_app: 'Evergiving Test'
+    }
+  end
+
+  def test_successful_store
+    @gateway.expects(:ssl_post).returns(successful_store_response)
+    response = @gateway.store(@credit_card, @options)
+
+    assert_success response
+    assert_equal '1a738830-03f4-4f1a-8ccd-3b11dc211113', response.authorization
+  end
+
+  def test_failed_store
+    @gateway.expects(:ssl_post).returns(failed_store_response)
+    response = @gateway.store(@credit_card, @options)
+
+    assert_failure response
+    assert_equal 'Credit card number is not valid.', response.message  end
+
+  def test_scrub
+    assert @gateway.supports_scrubbing?
+    assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
+  end
+
+  private
+
+  def pre_scrubbed
+    <<-XML
+opening connection to bbec1test2.blackbaud.com.au:443...
+opened
+starting SSL for bbec1test2.blackbaud.com.au:443...
+SSL established
+<- "POST /bbAppFx/AppFxWebService.asmx HTTP/1.1\r\nContent-Type: text/xml; charset=utf-8\r\nHost: bbec1test2.blackbaud.com.au\r\nSoapaction: Blackbaud.AppFx.WebService.API.1/CreditCardVault\r\nAuthorization: Basic Zm9vOmJhcg==\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nContent-Length: 703\r\n\r\n"
+<- "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soap12:Envelope xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:soap12=\"http://www.w3.org/2003/05/soap-envelope\"><soap12:Body><CreditCardVaultRequest xmlns=\"Blackbaud.AppFx.WebService.API.1\"><ClientAppInfo REDatabaseToUse=\"BBInfinity\" ClientAppName=\"Evergiving Test\" TimeOutSeconds=\"100\" RunAsUserID=\"00000000-0000-0000-0000-000000000000\"/><CreditCards><CreditCardInfo><CardHolder>Longbob Longsen</CardHolder><CardNumber>4000100011112224</CardNumber><ExpirationDate><Month>09</Month><Year>2018</Year></ExpirationDate></CreditCardInfo></CreditCards></CreditCardVaultRequest></soap12:Body></soap12:Envelope>\n"
+-> "HTTP/1.1 200 OK\r\n"
+-> "Cache-Control: private, max-age=0\r\n"
+-> "Content-Type: application/soap+xml; charset=utf-8\r\n"
+-> "Server: Microsoft-IIS/7.5\r\n"
+-> "X-AspNet-Version: 4.0.30319\r\n"
+-> "X-Frame-Options: sameorigin\r\n"
+-> "Date: Wed, 06 Dec 2017 01:57:56 GMT\r\n"
+-> "Connection: close\r\n"
+-> "Content-Length: 499\r\n"
+-> "\r\n"
+reading 499 bytes...
+-> "<?xml version=\"1.0\" encoding=\"utf-8\"?><soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><soap:Body><CreditCardVaultReply xmlns=\"Blackbaud.AppFx.WebService.API.1\"><CreditCardResponses><CreditCardVaultResponse><Token>1a738830-03f4-4f1a-8ccd-3b11dc211113</Token><Status>Success</Status></CreditCardVaultResponse></CreditCardResponses></CreditCardVaultReply></soap:Body></soap:Envelope>"
+read 499 bytes
+Conn close
+    XML
+  end
+
+  def post_scrubbed
+    <<-XML
+opening connection to bbec1test2.blackbaud.com.au:443...
+opened
+starting SSL for bbec1test2.blackbaud.com.au:443...
+SSL established
+<- "POST /bbAppFx/AppFxWebService.asmx HTTP/1.1\r\nContent-Type: text/xml; charset=utf-8\r\nHost: bbec1test2.blackbaud.com.au\r\nSoapaction: Blackbaud.AppFx.WebService.API.1/CreditCardVault\r\nAuthorization: Basic [FILTERED]==\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nContent-Length: 703\r\n\r\n"
+<- "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soap12:Envelope xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:soap12=\"http://www.w3.org/2003/05/soap-envelope\"><soap12:Body><CreditCardVaultRequest xmlns=\"Blackbaud.AppFx.WebService.API.1\"><ClientAppInfo REDatabaseToUse=\"BBInfinity\" ClientAppName=\"Evergiving Test\" TimeOutSeconds=\"100\" RunAsUserID=\"00000000-0000-0000-0000-000000000000\"/><CreditCards><CreditCardInfo><CardHolder>Longbob Longsen</CardHolder><CardNumber>[FILTERED]</CardNumber><ExpirationDate><Month>09</Month><Year>2018</Year></ExpirationDate></CreditCardInfo></CreditCards></CreditCardVaultRequest></soap12:Body></soap12:Envelope>\n"
+-> "HTTP/1.1 200 OK\r\n"
+-> "Cache-Control: private, max-age=0\r\n"
+-> "Content-Type: application/soap+xml; charset=utf-8\r\n"
+-> "Server: Microsoft-IIS/7.5\r\n"
+-> "X-AspNet-Version: 4.0.30319\r\n"
+-> "X-Frame-Options: sameorigin\r\n"
+-> "Date: Wed, 06 Dec 2017 01:57:56 GMT\r\n"
+-> "Connection: close\r\n"
+-> "Content-Length: 499\r\n"
+-> "\r\n"
+reading 499 bytes...
+-> "<?xml version=\"1.0\" encoding=\"utf-8\"?><soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><soap:Body><CreditCardVaultReply xmlns=\"Blackbaud.AppFx.WebService.API.1\"><CreditCardResponses><CreditCardVaultResponse><Token>1a738830-03f4-4f1a-8ccd-3b11dc211113</Token><Status>Success</Status></CreditCardVaultResponse></CreditCardResponses></CreditCardVaultReply></soap:Body></soap:Envelope>"
+read 499 bytes
+Conn close
+    XML
+  end
+
+  def successful_store_response
+    %(
+      <?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><CreditCardVaultReply xmlns="Blackbaud.AppFx.WebService.API.1"><CreditCardResponses><CreditCardVaultResponse><Token>1a738830-03f4-4f1a-8ccd-3b11dc211113</Token><Status>Success</Status></CreditCardVaultResponse></CreditCardResponses></CreditCardVaultReply></soap:Body></soap:Envelope>
+    )
+  end
+
+  def failed_store_response
+    %(
+      <?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><CreditCardVaultReply xmlns="Blackbaud.AppFx.WebService.API.1"><CreditCardResponses><CreditCardVaultResponse><Token>00000000-0000-0000-0000-000000000000</Token><Status>Fail</Status><ErrorMessage>Credit card number is not valid.</ErrorMessage></CreditCardVaultResponse></CreditCardResponses></CreditCardVaultReply></soap:Body></soap:Envelope>
+    )
+  end
+end


### PR DESCRIPTION
Introduces support for Blackbaud's BBPS creditcard tokenisation service. This is not a proper payment gateway and so I won't be pushing this upstream.

This vault is necessary for customers that use Blackbaud and want to use the token for debits directly from the CRM.