### PR TITLE
Add skeleton for Zuora (only store)

### DIFF
--- a/lib/active_merchant/billing/gateways/zuora.rb
+++ b/lib/active_merchant/billing/gateways/zuora.rb
@@ -1,0 +1,170 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class ZuoraGateway < Gateway
+      self.test_url = 'https://rest.apisandbox.zuora.com/v1/'
+      self.live_url = 'https://rest.zuora.com/v1/'
+
+      self.supported_countries = ['AU']
+      self.default_currency = 'AUD'
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover]
+
+      self.homepage_url = 'https://www.zuora.com/'
+      self.display_name = 'Zuora'
+
+      CARD_BRAND_MAP = {
+        'visa'              => 'Visa',
+        'mastercard'        => 'Mastercard',
+        'american_express'  => 'AmericanExpress',
+        'discover'          => 'Discover'
+      }.freeze
+
+      def initialize(options = {})
+        requires!(options, :username, :password)
+        super
+      end
+
+      def store(credit_card, options = {})
+        post = {}
+        add_address(post, options)
+        add_payment(post, credit_card, options)
+        add_store_options(post, options)
+        commit('accounts', post)
+      end
+
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript.
+          gsub(%r((apiAccessKeyId: )[^\s\\]+)i, '\1[FILTERED]').
+          gsub(%r((apiSecretAccessKey: )[^\s\\]+)i, '\1[FILTERED]').
+          gsub(%r((cardNumber\\\":\\\")\d+)i, '\1[FILTERED]').
+          gsub(%r((securityCode\\\":\\\")\d+)i, '\1[FILTERED]')
+      end
+
+      private
+
+      def add_address(post, options)
+        if (address = (options[:billing_address] || options[:address]))
+          post[:billToContact] = {
+            address1: address[:address1],
+            city: address[:city],
+            state: address[:state],
+            zipCode: address[:zip],
+            country: address[:country],
+            workEmail: options[:email],
+            firstName: options[:first_name],
+            lastName: options[:last_name]
+          }.reject { |_, v| v.blank? }
+        end
+      end
+
+      def add_payment(post, payment, options = {})
+        if payment.respond_to?(:number)
+          post[:currency] = options[:currency]
+          post[:creditCard] = {
+            cardNumber: payment.number,
+            cardType: CARD_BRAND_MAP.fetch(payment.brand),
+            expirationMonth: format(payment.month, :two_digits),
+            expirationYear: format(payment.year, :four_digits),
+            securityCode: payment.verification_value
+          }.reject { |_, v| v.blank? }
+        end
+      end
+
+      def add_store_options(post, options = {})
+        post[:autoPay] = true
+        post[:billCycleDay] = 0
+        post[:invoiceDeliveryPrefsEmail] = options[:email].present?
+        post[:invoiceDeliveryPrefsPrint] = false
+        post[:name] = options[:description]
+      end
+
+      def parse(body)
+        return {} unless body
+        JSON.parse(body)
+      end
+
+      def url(action)
+        base_url = test? ? test_url : live_url
+
+        base_url + action
+      end
+
+      def api_request(action, parameters, options = {})
+        raw_response = response = nil
+        begin
+          raw_response = ssl_post(url(action), parameters.to_json, headers)
+          response = parse(raw_response)
+        rescue ResponseError => e
+          raw_response = e.response.body
+          response = response_error(raw_response)
+        rescue JSON::ParserError
+          response = json_error(raw_response)
+        end
+        response
+      end
+
+      def commit(action, parameters, options = {})
+        response = api_request(action, parameters, options)
+
+        Response.new(
+          success_from(response),
+          message_from(response),
+          response,
+          authorization: authorization_from(action, response),
+          test: test?,
+          error_code: error_code_from(response)
+        )
+      end
+
+      def headers
+        headers = {
+          'Content-Type'       => 'application/json',
+          'User-Agent'         => "ActiveMerchantBindings/#{ActiveMerchant::VERSION}",
+          'apiAccessKeyId'     => @options[:username],
+          'apiSecretAccessKey' => @options[:password]
+        }
+
+        headers
+      end
+
+      def success_from(response)
+        response['success']
+      end
+
+      def message_from(response)
+        return response['reasons'].map { |e| e['message'] }.join(', ') unless success_from(response)
+      end
+
+      def response_error(raw_response)
+        parse(raw_response)
+      rescue JSON::ParserError
+        json_error(raw_response)
+      end
+
+      def json_error(raw_response)
+        msg = 'Invalid response received from the Zuora API.  Please contact Zuora support if you continue to receive this message.'
+        msg += "  (The raw response returned by the API was #{raw_response.inspect})"
+        {
+          'reasons' => [{
+            'code' => '50000000',
+            'message' => msg
+          }]
+        }
+      end
+
+      def authorization_from(action, response)
+        case action
+        when 'accounts'
+          response['accountId']
+        end
+      end
+
+      def error_code_from(response)
+        return response['reasons'].map { |e| e['code'] }.join(', ') unless success_from(response)
+      end
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -1267,3 +1267,7 @@ worldpay_us:
   acctid: MPNAB
   subid: SPREE
   merchantpin: "1234567890"
+
+zuora:
+  username: USERNAME
+  password: PASSWORD

--- a/test/remote/gateways/remote_zuora_test.rb
+++ b/test/remote/gateways/remote_zuora_test.rb
@@ -1,0 +1,50 @@
+require 'test_helper'
+
+class RemoteZuoraTest < Test::Unit::TestCase
+  def setup
+    @gateway = ZuoraGateway.new(fixtures(:zuora))
+
+    @credit_card = credit_card('4000100011112224', verification_value: nil)
+    @options = {
+      billing_address: address,
+      first_name: 'Bob',
+      last_name: 'Longsen',
+      currency: 'AUD',
+      description: 'Store Purchase'
+    }
+    @failed_options = {
+      first_name: 'Bob',
+      last_name: 'Longsen',
+    }
+  end
+
+  def test_successful_store
+    response = @gateway.store(@credit_card, @options)
+
+    assert_success response
+  end
+
+  def test_failed_store
+    response = @gateway.store(@credit_card, @failed_options)
+    
+    assert_failure response
+    assert_match /'billToContact' may not be null/, response.message
+  end
+
+  def test_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.store(@credit_card, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card.number, transcript)
+    assert_scrubbed(@gateway.options[:password], transcript)
+  end
+
+  def test_invalid_login
+    gateway = ZuoraGateway.new(username: 'active_merchant_test', password: 'sekrit')
+    assert response = gateway.store(@credit_card, @options)
+    assert_failure response
+    assert_match 'this resource is protected, please sign in first', response.message
+  end
+end

--- a/test/unit/gateways/zuora_test.rb
+++ b/test/unit/gateways/zuora_test.rb
@@ -1,0 +1,125 @@
+require 'test_helper'
+
+class ZuoraTest < Test::Unit::TestCase
+  def setup
+    @gateway = ZuoraGateway.new(username: 'login', password: 'password')
+    @credit_card = credit_card
+
+    @options = {
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
+    }
+    @failed_options = {
+      order_id: '1'
+    }
+  end
+
+  def test_successful_store
+    @gateway.expects(:ssl_post).returns(successful_store_response)
+
+    response = @gateway.store(@credit_card, @options)
+    assert_success response
+
+    assert_equal '2c92c0fa6068c1dd016068ff41251bb5', response.authorization
+    assert response.test?
+  end
+
+  def test_failed_store
+    @gateway.expects(:ssl_post).returns(failed_store_response)
+
+    response = @gateway.store(@credit_card, @failed_options)
+    assert_failure response
+
+    assert_match /'billToContact' may not be null/, response.message
+  end
+
+  def test_scrub
+    assert @gateway.supports_scrubbing?
+    assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
+  end
+
+  private
+
+  def pre_scrubbed
+    %q(
+      opening connection to rest.apisandbox.zuora.com:443...
+      opened
+      starting SSL for rest.apisandbox.zuora.com:443...
+      SSL established
+      <- "POST /v1/accounts HTTP/1.1\r\nContent-Type: application/json\r\nUser-Agent: ActiveMerchantBindings/1.70.0\r\nApiaccesskeyid: foo\r\nApisecretaccesskey: bar\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nConnection: close\r\nHost: rest.apisandbox.zuora.com\r\nContent-Length: 422\r\n\r\n"
+      <- "{\"billToContact\":{\"address1\":\"456 My Street\",\"city\":\"Ottawa\",\"state\":\"ON\",\"zipCode\":\"K1C2N6\",\"country\":\"CA\",\"firstName\":\"Bob\",\"lastName\":\"Longsen\"},\"currency\":\"AUD\",\"creditCard\":{\"cardNumber\":\"4000100011112224\",\"cardType\":\"Visa\",\"expirationMonth\":\"09\",\"expirationYear\":\"2018\",\"securityCode\":\"123\"},\"autoPay\":true,\"billCycleDay\":0,\"invoiceDeliveryPrefsEmail\":false,\"invoiceDeliveryPrefsPrint\":false,\"name\":\"Store Purchase\"}"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Content-Type: application/json;charset=utf-8\r\n"
+      -> "Server: Zuora App\r\n"
+      -> "x-request-id: 8e4fda2d-d977-4643-827d-b9abd61d2c29\r\n"
+      -> "X-Kong-Upstream-Latency: 2122\r\n"
+      -> "X-Kong-Proxy-Latency: 0\r\n"
+      -> "Date: Mon, 18 Dec 2017 10:16:59 GMT\r\n"
+      -> "Content-Length: 165\r\n"
+      -> "Connection: close\r\n"
+      -> "Set-Cookie: ZSession=-jut7AtmxKwJOpdTT0oKsoTAikqaj3ZmfLKpaoFOYOQc_WXCm1409iE9XxLIHIIB9ID05fVqnVqZgt9inkrtJ3jWIh6iMMedv8Ljh9zF3489_8D91EFRcSeSd7Pn_o8dsbl2I7ilYYZ9Wn8066t5pCzosnt3_60weM_NXKB0RLopFV5D58Pwd-dBiO2XSJgLnVU8bAWnNmPqLqBg-7Sbf6cbChxxDfOv6CU-9asQodgNNG0bCxDx5sIUgHwy7fL8CG-FU3ekL5Zlc1vfrZdTpDmfNpk1PrELzdWPVftktCj-FHrd1XTsasjTzC1rzbR-rewL7usFwhk4839Pt6_qm-m01YiMn30rqk6xw04YJ0U%3D; Path=/; Secure; HttpOnly\r\n"
+      -> "\r\n"
+      reading 165 bytes...
+      -> "{\n  \"success\" : true,\n  \"accountId\" : \"2c92c0fb6068c83d016069205ece2945\",\n  \"accountNumber\" : \"A00002791\",\n  \"paymentMethodId\" : \"2c92c0fb6068c83d0160692066c6294b\"\n}"
+      read 165 bytes
+      Conn close
+    )
+  end
+
+  def post_scrubbed
+    %q(
+      opening connection to rest.apisandbox.zuora.com:443...
+      opened
+      starting SSL for rest.apisandbox.zuora.com:443...
+      SSL established
+      <- "POST /v1/accounts HTTP/1.1\r\nContent-Type: application/json\r\nUser-Agent: ActiveMerchantBindings/1.70.0\r\nApiaccesskeyid: [FILTERED]\r\nApisecretaccesskey: [FILTERED]\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nConnection: close\r\nHost: rest.apisandbox.zuora.com\r\nContent-Length: 422\r\n\r\n"
+      <- "{\"billToContact\":{\"address1\":\"456 My Street\",\"city\":\"Ottawa\",\"state\":\"ON\",\"zipCode\":\"K1C2N6\",\"country\":\"CA\",\"firstName\":\"Bob\",\"lastName\":\"Longsen\"},\"currency\":\"AUD\",\"creditCard\":{\"cardNumber\":\"[FILTERED]\",\"cardType\":\"Visa\",\"expirationMonth\":\"09\",\"expirationYear\":\"2018\",\"securityCode\":\"[FILTERED]\"},\"autoPay\":true,\"billCycleDay\":0,\"invoiceDeliveryPrefsEmail\":false,\"invoiceDeliveryPrefsPrint\":false,\"name\":\"Store Purchase\"}"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Content-Type: application/json;charset=utf-8\r\n"
+      -> "Server: Zuora App\r\n"
+      -> "x-request-id: 8e4fda2d-d977-4643-827d-b9abd61d2c29\r\n"
+      -> "X-Kong-Upstream-Latency: 2122\r\n"
+      -> "X-Kong-Proxy-Latency: 0\r\n"
+      -> "Date: Mon, 18 Dec 2017 10:16:59 GMT\r\n"
+      -> "Content-Length: 165\r\n"
+      -> "Connection: close\r\n"
+      -> "Set-Cookie: ZSession=-jut7AtmxKwJOpdTT0oKsoTAikqaj3ZmfLKpaoFOYOQc_WXCm1409iE9XxLIHIIB9ID05fVqnVqZgt9inkrtJ3jWIh6iMMedv8Ljh9zF3489_8D91EFRcSeSd7Pn_o8dsbl2I7ilYYZ9Wn8066t5pCzosnt3_60weM_NXKB0RLopFV5D58Pwd-dBiO2XSJgLnVU8bAWnNmPqLqBg-7Sbf6cbChxxDfOv6CU-9asQodgNNG0bCxDx5sIUgHwy7fL8CG-FU3ekL5Zlc1vfrZdTpDmfNpk1PrELzdWPVftktCj-FHrd1XTsasjTzC1rzbR-rewL7usFwhk4839Pt6_qm-m01YiMn30rqk6xw04YJ0U%3D; Path=/; Secure; HttpOnly\r\n"
+      -> "\r\n"
+      reading 165 bytes...
+      -> "{\n  \"success\" : true,\n  \"accountId\" : \"2c92c0fb6068c83d016069205ece2945\",\n  \"accountNumber\" : \"A00002791\",\n  \"paymentMethodId\" : \"2c92c0fb6068c83d0160692066c6294b\"\n}"
+      read 165 bytes
+      Conn close
+    )
+  end
+
+  def successful_store_response
+    <<-JSON
+      {
+        "success" : true,
+        "accountId" : "2c92c0fa6068c1dd016068ff41251bb5",
+        "accountNumber" : "A00002783",
+        "paymentMethodId" : "2c92c0fa6068c1dd016068ff493e1bbb"
+      }
+    JSON
+  end
+
+  def failed_store_response
+    <<-JSON
+      {
+        "success" : false,
+        "processId" : "2E49DC014ABB9366",
+        "reasons" : [ {
+          "code" : 51000220,
+          "message" : "'name' may not be empty"
+        }, {
+          "code" : 51001122,
+          "message" : "'billToContact' may not be null"
+        }, {
+          "code" : 51000322,
+          "message" : "'currency' may not be null"
+        } ]
+      }
+    JSON
+  end
+end


### PR DESCRIPTION
Adds the skeleton for Zuora that implements tokenisation only and only for Australia for the time being. I am not 100% familiar with all the currencies and territories that are supported by Zuora, given their size, it's probably quite a lot.