### PR TITLE
Add support for Ezidebit gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/ezidebit.rb
+++ b/lib/active_merchant/billing/gateways/ezidebit.rb
@@ -1,0 +1,303 @@
+# frozen_string_literal: true
+
+require 'nokogiri'
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class EzidebitGateway < Gateway
+      include Empty
+
+      self.test_url = 'https://api.demo.ezidebit.com.au/v3-5/'
+      self.live_url = 'https://api.ezidebit.com.au/v3-5/'
+
+      self.supported_countries = ['AU', 'NZ']
+      self.default_currency = 'AUD'
+      self.money_format = :cents
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover]
+
+      self.homepage_url = 'https://www.getpayments.com/'
+      self.display_name = 'Ezidebit'
+
+      STANDARD_ERROR_CODE_MAPPING = {
+        14 => STANDARD_ERROR_CODE[:invalid_number],
+        54 => STANDARD_ERROR_CODE[:expired_card],
+        55 => STANDARD_ERROR_CODE[:incorrect_pin],
+        1 => STANDARD_ERROR_CODE[:card_declined],
+        2 => STANDARD_ERROR_CODE[:card_declined],
+        3 => STANDARD_ERROR_CODE[:processing_error],
+        5 => STANDARD_ERROR_CODE[:card_declined],
+        51 => STANDARD_ERROR_CODE[:card_declined],
+        4 => STANDARD_ERROR_CODE[:pickup_card],
+        7 => STANDARD_ERROR_CODE[:pickup_card],
+        33 => STANDARD_ERROR_CODE[:pickup_card],
+        34 => STANDARD_ERROR_CODE[:pickup_card],
+        35 => STANDARD_ERROR_CODE[:pickup_card],
+        36 => STANDARD_ERROR_CODE[:pickup_card],
+        37 => STANDARD_ERROR_CODE[:pickup_card],
+        96 => STANDARD_ERROR_CODE[:config_error],
+        98 => STANDARD_ERROR_CODE[:config_error]
+      }.freeze
+
+      ENV_NS = { 'xmlns:soapenv' => 'http://schemas.xmlsoap.org/soap/envelope/', 'xmlns:px' => 'https://px.ezidebit.com.au/' }
+      SOAP_ACTION_PCI_NS = 'https://px.ezidebit.com.au/IPCIService/'
+      SOAP_ACTION_NONPCI_NS = 'https://px.ezidebit.com.au/INonPCIService/'
+
+      def initialize(options={})
+        requires!(options, :digital_key)
+        super
+      end
+
+      def purchase(money, payment, options = {})
+        request = build_soap_request do |xml|
+          xml['px'].ProcessRealtimeCreditCardPayment do
+            add_authentication(xml)
+            add_payment(xml, payment)
+            add_invoice(xml, money, options)
+            add_customer_data(xml, options)
+          end
+        end
+
+        commit('ProcessRealtimeCreditCardPayment', request, options)
+      end
+
+      def store(payment, options = {})
+        MultiResponse.run do |r|
+          r.process { add_customer_details(options) }
+          r.process { add_card_to_customer(payment, options) }
+        end        
+      end
+
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript.
+          gsub(%r((<px:DigitalKey>)[^<]*(</px:DigitalKey>))i, '\1[FILTERED]\2').
+          gsub(%r((<px:CreditCardNumber>)[^<]*(</px:CreditCardNumber>))i, '\1[FILTERED]\2').
+          gsub(%r((<px:CreditCardCCV>).+(</px:CreditCardCCV>))i, '\1[FILTERED]\2')
+      end
+
+      private
+
+      # private
+      # adding a customer requires a vast number of details to identify a
+      # customer (address, name, email, phone)
+      def add_customer_details(options = {})
+        request = build_soap_request do |xml|
+          xml['px'].AddCustomer do
+            add_authentication(xml)
+            address = options[:billing_address] || options[:address]
+            xml['px'].YourSystemReference options[:order_id]
+            xml['px'].LastName options[:last_name]
+            xml['px'].FirstName options[:first_name]
+            xml['px'].AddressLine1 address[:address1] if address[:address1]
+            xml['px'].AddressLine2 address[:address2] if address[:address2]
+            xml['px'].AddressSuburb address[:city] if address[:city]
+            xml['px'].AddressState address[:state] if address[:state]
+            xml['px'].AddressPostCode address[:zip] if address[:zip]
+            xml['px'].EmailAddress options[:email] unless empty?(options[:email])
+            xml['px'].MobilePhoneNumber options[:mobile_phone] unless empty?(options[:mobile_phone])
+            xml['px'].ContractStartDate options[:start_date]
+            xml['px'].SmsPaymentReminder 'NO'
+            xml['px'].SmsFailedNotification 'NO'
+            xml['px'].SmsExpiredCard 'NO'
+          end
+        end
+
+        commit('AddCustomer', request, options)
+      end
+
+      # private
+      # when tokenising, we add the card to the customer via an edit
+      # customer endpoint.
+      def add_card_to_customer(payment, options = {})
+        request = build_soap_request do |xml|
+          xml['px'].EditCustomerCreditCard do
+            add_authentication(xml)
+            xml['px'].EziDebitCustomerID
+            xml['px'].YourSystemReference options[:order_id]
+            add_payment(xml, payment)
+            xml['px'].Reactivate 'YES'
+          end
+        end
+
+        commit('EditCustomerCreditCard', request, options)
+      end
+
+      # private
+      # the documentation only refers to the use of the digital_key for
+      # authentication
+      def add_authentication(xml)
+        xml['px'].DigitalKey @options[:digital_key]
+      end
+
+      # private
+      # used for realtime creditcard payment, the customer name
+      # is mandatory
+      def add_customer_data(xml, options)
+        xml['px'].CustomerName options[:customer_name]
+      end
+
+      # private
+      # payment/amount details
+      def add_invoice(xml, money, options)
+        xml['px'].PaymentAmountInCents amount(money)
+        xml['px'].PaymentReference options[:order_id] || SecureRandom.hex(10)
+      end
+
+      # private
+      # credit card details for tokenisation and payments
+      def add_payment(xml, payment)
+        xml['px'].CreditCardNumber payment.number
+        xml['px'].CreditCardExpiryMonth format(payment.month, :two_digits)
+        xml['px'].CreditCardExpiryYear format(payment.year, :four_digits)
+        xml['px'].CreditCardCCV payment.verification_value if payment.verification_value
+        xml['px'].NameOnCreditCard payment.name
+      end
+
+      def parse(body, action)
+        doc = Nokogiri::XML(body)
+        doc.remove_namespaces!
+
+        response = {}
+
+        response[:response_code] = if (element = doc.at_xpath("//#{action}Result/Data/PaymentResultCode"))
+          (empty?(element.content) ? nil : element.content.to_i)
+        end
+
+        response[:response_message] = if (element = doc.at_xpath("//#{action}Result/Data/PaymentResultText"))
+          (empty?(element.content) ? nil : element.content)
+        end
+
+        response[:bank_receipt_id] = if (element = doc.at_xpath("//#{action}Result/Data/BankReceiptID"))
+          (empty?(element.content) ? nil : element.content)
+        end
+
+        response[:exchange_payment_id] = if (element = doc.at_xpath("//#{action}Result/Data/ExchangePaymentID"))
+          (empty?(element.content) ? nil : element.content)
+        end
+
+        response[:approved] = if (element = doc.at_xpath("//#{action}Result/Data/PaymentResult"))
+          (empty?(element.content) ? false : element.content)
+        end
+
+        response[:error_code] = if (element = doc.at_xpath("//#{action}Result/Error"))
+          (empty?(element.content) ? false : element.content)
+        end
+
+        response[:error_message] = if (element = doc.at_xpath("//#{action}Result/ErrorMessage"))
+          (empty?(element.content) ? false : element.content)
+        end
+
+        response[:customer_ref] = if (element = doc.at_xpath("//#{action}Result/Data/CustomerRef"))
+          (empty?(element.content) ? false : element.content)
+        end
+
+        response[:customer_store] = if (element = doc.at_xpath("//#{action}Result/Data"))
+          (empty?(element.content) ? false : element.content)
+        end
+
+        response
+      end
+
+      # private
+      # returns the corresponding header to send as a SOAPAction
+      def soap_action_namespace(action)
+        ns = if action == 'AddCustomer'
+               SOAP_ACTION_NONPCI_NS
+             else
+               SOAP_ACTION_PCI_NS
+             end
+
+        "#{ns}#{action}"
+      end
+
+      # private
+      # builds the headers we will send with our HTTP request
+      def headers(action)
+        {
+          'Content-Type' => 'text/xml',
+          'SOAPAction'   => soap_action_namespace(action)
+        }
+      end
+
+      # private
+      # a way to select the correct URL to talk to
+      def url(action)
+        # Joy! AddCustomer does not use the same URL as the payments
+        # or editing of the customer details to add the card
+        endpoint = if action == 'AddCustomer'
+                     'nonpci'
+                   else
+                     'pci'
+                   end
+
+        url = test? ? test_url : live_url
+
+        "#{url}#{endpoint}"
+      end
+
+      # private
+      # yup ... calling Ezidebit from here
+      def commit(action, xml, parameters)
+        response = parse(ssl_post(url(action), xml, headers(action)), action)
+
+        Response.new(
+          success_from(response, action),
+          message_from(response, action),
+          response,
+          authorization: authorization_from(response, action, parameters),
+          test: test?,
+          error_code: error_code_from(response, action)
+        )
+      end
+
+      def success_from(response, action)
+        if action == 'EditCustomerCreditCard'
+          response[:customer_store] == 'S'
+        else
+          response[:error_code] == '0' && (response[:customer_ref].present? || response[:response_code] == 0)
+        end
+      end
+
+      def message_from(response, action)
+        if success_from(response, action)
+          response[:response_message]
+        else
+          response[:error_message]
+        end
+      end
+
+      # note for the `store` action, we use the `:order_id` that we pass
+      # as the authorisation, since that's a reference that's searchable
+      # via the admin ui
+      def authorization_from(response, action, options)
+        if action == 'AddCustomer'
+          response[:customer_ref]
+        elsif action == 'EditCustomerCreditCard'
+          options[:order_id]
+        else
+          [response[:bank_receipt_id], response[:exchange_payment_id]].join('|')
+        end
+      end
+
+      def build_soap_request
+        builder = Nokogiri::XML::Builder.new(encoding: 'UTF-8') do |xml|
+          xml['soapenv'].Envelope(ENV_NS) do
+            xml['soapenv'].Header
+            xml['soapenv'].Body do
+              yield(xml)
+            end
+          end
+        end
+
+        builder.to_xml
+      end
+
+      def error_code_from(response, action)
+        STANDARD_ERROR_CODE_MAPPING.fetch(response[:response_code], 1) unless success_from(response, action)
+      end
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -295,6 +295,9 @@ exact:
 ezic:
   account_id: "120536457270"
 
+ezidebit:
+  digital_key: DIGITAL_KEY
+
 # Working credentials, no need to replace
 fat_zebra:
   username: TEST

--- a/test/remote/gateways/remote_ezidebit_test.rb
+++ b/test/remote/gateways/remote_ezidebit_test.rb
@@ -1,0 +1,69 @@
+require 'test_helper'
+
+class RemoteEzidebitTest < Test::Unit::TestCase
+  def setup
+    @gateway = EzidebitGateway.new(fixtures(:ezidebit))
+
+    @amount = 100
+    @credit_card = credit_card('4987654321098769', month: 5, year: 2021, verification_value: 454)
+    @declined_amount = 105
+    @options = {
+      order_id: SecureRandom.uuid,
+      description: 'Store Purchase',
+      customer_name: 'Longsen Longbob'
+    }
+    @address = {
+        address1: '456 My Street',
+        address2: 'Apt 1',
+        company:  'Widgets Inc',
+        city:     'Bondi Beach',
+        state:    'NSW',
+        zip:      '2026',
+        country:  'AU'
+    }
+    @store_options = @options.merge(
+      billing_address: @address,
+      start_date: '2018-01-11',
+      last_name: 'Longsen',
+      first_name: 'Longbob'
+    )
+  end
+
+  def test_successful_purchase
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'APPROVED', response.message
+  end
+
+  def test_failed_purchase
+    response = @gateway.purchase(@declined_amount, @credit_card, @options)
+    assert_failure response
+    assert_equal 'Declined', response.message
+  end
+
+  def test_successful_store
+    response = @gateway.store(@credit_card, @store_options)
+    assert_success response
+    assert_equal response.authorization, @store_options[:order_id]
+  end
+
+  def test_invalid_login
+    gateway = EzidebitGateway.new(digital_key: '')
+
+    response = gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_match %r{You must provide a value for the \'DigitalKey\' parameter \(WSvc\)}, response.message
+  end
+
+  def test_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card.number, transcript)
+    assert_scrubbed(@credit_card.verification_value, transcript)
+    assert_scrubbed(@gateway.options[:client_id], transcript)
+  end
+
+end

--- a/test/unit/gateways/ezidebit_test.rb
+++ b/test/unit/gateways/ezidebit_test.rb
@@ -1,0 +1,186 @@
+require 'test_helper'
+
+class EzidebitTest < Test::Unit::TestCase
+  include CommStub
+
+  def setup
+    @gateway = EzidebitGateway.new(digital_key: 'login')
+    @credit_card = credit_card
+    @amount = 100
+
+    @options = {
+      order_id: '82a01ca3-0907-4252-a862-6d473259c51c',
+      billing_address: address,
+      description: 'Store Purchase'
+    }
+
+    @store_options = @options.merge(
+      first_name: 'Longbob',
+      last_name: 'Longsen'
+    )
+  end
+
+  def test_successful_purchase
+    @gateway.expects(:ssl_post).returns(successful_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+
+    assert_equal '5372343|6745860', response.authorization
+    assert response.test?
+  end
+
+  def test_failed_purchase
+    @gateway.expects(:ssl_post).returns(failed_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal Gateway::STANDARD_ERROR_CODE[:card_declined], response.error_code
+  end
+
+  def test_successful_store
+    response = stub_comms do
+      @gateway.store(@credit_card, @options)
+    end.respond_with(successful_add_customer_response, successful_add_card_to_customer_response)
+    assert_success response
+    assert_equal '82a01ca3-0907-4252-a862-6d473259c51c', response.authorization
+  end
+
+  def test_scrub
+    assert @gateway.supports_scrubbing?
+    assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
+  end
+
+  private
+
+  def pre_scrubbed
+    <<-XML
+opening connection to api.demo.ezidebit.com.au:443...
+opened
+starting SSL for api.demo.ezidebit.com.au:443...
+SSL established
+<- "POST /v3-5/pci HTTP/1.1\r\nContent-Type: text/xml\r\nSoapaction: https://px.ezidebit.com.au/IPCIService/ProcessRealtimeCreditCardPayment\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: api.demo.ezidebit.com.au\r\nContent-Length: 895\r\n\r\n"
+<- "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:px=\"https://px.ezidebit.com.au/\">\n  <soapenv:Header/>\n  <soapenv:Body>\n    <px:ProcessRealtimeCreditCardPayment>\n      <px:DigitalKey>52F2BCEE-E582-4396-AF8E-898DDD7C44FE</px:DigitalKey>\n      <px:CreditCardNumber>4987654321098769</px:CreditCardNumber>\n      <px:CreditCardExpiryMonth>05</px:CreditCardExpiryMonth>\n      <px:CreditCardExpiryYear>2021</px:CreditCardExpiryYear>\n      <px:CreditCardCCV>454</px:CreditCardCCV>\n      <px:NameOnCreditCard>Longbob Longsen</px:NameOnCreditCard>\n      <px:PaymentAmountInCents>100</px:PaymentAmountInCents>\n      <px:PaymentReference>203e8a50-b480-4c85-82d6-ecafc1154640</px:PaymentReference>\n      <px:CustomerName>Longsen Longbob</px:CustomerName>\n    </px:ProcessRealtimeCreditCardPayment>\n  </soapenv:Body>\n</soapenv:Envelope>\n"
+-> "HTTP/1.1 200 OK\r\n"
+-> "Cache-Control: private\r\n"
+-> "Content-Type: text/xml; charset=utf-8\r\n"
+-> "Server: Microsoft-IIS/10.0\r\n"
+-> "X-AspNet-Version: 4.0.30319\r\n"
+-> "Content-Length: 609\r\n"
+-> "Date: Thu, 11 Jan 2018 22:39:29 GMT\r\n"
+-> "Connection: close\r\n"
+-> "Set-Cookie: ASP.NET_SessionId=kf51kjsndazux1l0vjlec5jw; path=/; HttpOnly\r\n"
+-> "Set-Cookie: LTc5ySHAICXLdsZiATio=!vGIV3zyy8xE33IyFXo69uc0nq5wdI8msxxq3M+4Qc+tzzIFoGnvBdEB+8ngO3zidOQLhfo6mqAhsn4o=; path=/; Httponly; Secure\r\n"
+-> "Set-Cookie: f5avrbbbbbbbbbbbbbbbb=AHLDFKMNEKADJKFMEPHKCGFKAGEPDLKDKPICKGLLONEBGKJLDAOLBJLEEPOLJLLDKLIDDJMIFHMGLIPLHBEACAJCFOEPFCLIPADKGOFEMKFCEOAFMNIOGDDLDBGNNBOI; HttpOnly; secure\r\n"
+-> "\r\n"
+reading 609 bytes...
+-> "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\"><s:Body><ProcessRealtimeCreditCardPaymentResponse xmlns=\"https://px.ezidebit.com.au/\"><ProcessRealtimeCreditCardPaymentResult xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><Data><BankReceiptID>5372343</BankReceiptID><ExchangePaymentID>6745860</ExchangePaymentID><PaymentResult>A</PaymentResult><PaymentResultCode>00</PaymentResultCode><PaymentResultText>APPROVED</PaymentResultText></Data><Error>0</Error><ErrorMessage i:nil=\"true\"/></ProcessRealtimeCreditCardPaymentResult></ProcessRealtimeCreditCardPaymentResponse></s:Body></s:Envelope>"
+read 609 bytes
+Conn close
+    XML
+  end
+
+  def post_scrubbed
+    <<-XML
+opening connection to api.demo.ezidebit.com.au:443...
+opened
+starting SSL for api.demo.ezidebit.com.au:443...
+SSL established
+<- "POST /v3-5/pci HTTP/1.1\r\nContent-Type: text/xml\r\nSoapaction: https://px.ezidebit.com.au/IPCIService/ProcessRealtimeCreditCardPayment\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: api.demo.ezidebit.com.au\r\nContent-Length: 895\r\n\r\n"
+<- "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:px=\"https://px.ezidebit.com.au/\">\n  <soapenv:Header/>\n  <soapenv:Body>\n    <px:ProcessRealtimeCreditCardPayment>\n      <px:DigitalKey>[FILTERED]</px:DigitalKey>\n      <px:CreditCardNumber>[FILTERED]</px:CreditCardNumber>\n      <px:CreditCardExpiryMonth>05</px:CreditCardExpiryMonth>\n      <px:CreditCardExpiryYear>2021</px:CreditCardExpiryYear>\n      <px:CreditCardCCV>[FILTERED]</px:CreditCardCCV>\n      <px:NameOnCreditCard>Longbob Longsen</px:NameOnCreditCard>\n      <px:PaymentAmountInCents>100</px:PaymentAmountInCents>\n      <px:PaymentReference>203e8a50-b480-4c85-82d6-ecafc1154640</px:PaymentReference>\n      <px:CustomerName>Longsen Longbob</px:CustomerName>\n    </px:ProcessRealtimeCreditCardPayment>\n  </soapenv:Body>\n</soapenv:Envelope>\n"
+-> "HTTP/1.1 200 OK\r\n"
+-> "Cache-Control: private\r\n"
+-> "Content-Type: text/xml; charset=utf-8\r\n"
+-> "Server: Microsoft-IIS/10.0\r\n"
+-> "X-AspNet-Version: 4.0.30319\r\n"
+-> "Content-Length: 609\r\n"
+-> "Date: Thu, 11 Jan 2018 22:39:29 GMT\r\n"
+-> "Connection: close\r\n"
+-> "Set-Cookie: ASP.NET_SessionId=kf51kjsndazux1l0vjlec5jw; path=/; HttpOnly\r\n"
+-> "Set-Cookie: LTc5ySHAICXLdsZiATio=!vGIV3zyy8xE33IyFXo69uc0nq5wdI8msxxq3M+4Qc+tzzIFoGnvBdEB+8ngO3zidOQLhfo6mqAhsn4o=; path=/; Httponly; Secure\r\n"
+-> "Set-Cookie: f5avrbbbbbbbbbbbbbbbb=AHLDFKMNEKADJKFMEPHKCGFKAGEPDLKDKPICKGLLONEBGKJLDAOLBJLEEPOLJLLDKLIDDJMIFHMGLIPLHBEACAJCFOEPFCLIPADKGOFEMKFCEOAFMNIOGDDLDBGNNBOI; HttpOnly; secure\r\n"
+-> "\r\n"
+reading 609 bytes...
+-> "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\"><s:Body><ProcessRealtimeCreditCardPaymentResponse xmlns=\"https://px.ezidebit.com.au/\"><ProcessRealtimeCreditCardPaymentResult xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><Data><BankReceiptID>5372343</BankReceiptID><ExchangePaymentID>6745860</ExchangePaymentID><PaymentResult>A</PaymentResult><PaymentResultCode>00</PaymentResultCode><PaymentResultText>APPROVED</PaymentResultText></Data><Error>0</Error><ErrorMessage i:nil=\"true\"/></ProcessRealtimeCreditCardPaymentResult></ProcessRealtimeCreditCardPaymentResponse></s:Body></s:Envelope>"
+read 609 bytes
+Conn close
+    XML
+  end
+
+  def successful_purchase_response
+    <<-XML
+      <s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\">
+        <s:Body>
+          <ProcessRealtimeCreditCardPaymentResponse xmlns=\"https://px.ezidebit.com.au/\">
+            <ProcessRealtimeCreditCardPaymentResult xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\">
+              <Data>
+                <BankReceiptID>5372343</BankReceiptID>
+                <ExchangePaymentID>6745860</ExchangePaymentID>
+                <PaymentResult>A</PaymentResult>
+                <PaymentResultCode>00</PaymentResultCode>
+                <PaymentResultText>APPROVED</PaymentResultText>
+              </Data>
+              <Error>0</Error>
+              <ErrorMessage i:nil=\"true\"/>
+            </ProcessRealtimeCreditCardPaymentResult>
+          </ProcessRealtimeCreditCardPaymentResponse>
+        </s:Body>
+      </s:Envelope>
+    XML
+  end
+
+  def failed_purchase_response
+    <<-XML
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+        <s:Body>
+          <ProcessRealtimeCreditCardPaymentResponse xmlns="https://px.ezidebit.com.au/">
+            <ProcessRealtimeCreditCardPaymentResult xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+              <Data>
+                <BankReceiptID>5372344</BankReceiptID>
+                <ExchangePaymentID>6745864</ExchangePaymentID>
+                <PaymentResult>F</PaymentResult>
+                <PaymentResultCode>05</PaymentResultCode>
+                <PaymentResultText>DECLINED</PaymentResultText>
+              </Data>
+              <Error>0</Error>
+              <ErrorMessage>Declined</ErrorMessage>
+            </ProcessRealtimeCreditCardPaymentResult>
+          </ProcessRealtimeCreditCardPaymentResponse>
+        </s:Body>
+      </s:Envelope>
+    XML
+  end
+
+  def successful_add_customer_response
+    <<-XML
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+        <s:Body>
+          <AddCustomerResponse xmlns="https://px.ezidebit.com.au/">
+            <AddCustomerResult xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+              <Data xmlns:a="http://schemas.datacontract.org/2004/07/Ezidebit.PaymentExchange.V3_3.DataContracts">
+                <a:CustomerRef>782943</a:CustomerRef>
+              </Data>
+              <Error>0</Error>
+              <ErrorMessage i:nil="true"/>
+            </AddCustomerResult>
+          </AddCustomerResponse>
+        </s:Body>
+      </s:Envelope>
+    XML
+  end
+
+  def successful_add_card_to_customer_response
+    <<-XML
+      <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+        <s:Body xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+          <EditCustomerCreditCardResponse xmlns="https://px.ezidebit.com.au/">
+            <EditCustomerCreditCardResult>
+              <Error>0</Error>
+              <Data>S</Data>
+            </EditCustomerCreditCardResult>
+          </EditCustomerCreditCardResponse>
+        </s:Body>
+      </s:Envelope>
+    XML
+  end
+end


### PR DESCRIPTION
Ezidebit only seems to implement `purchase` and `store` via the SOAP API and not the usual suspects of `authorise`, `capture`, `void` and `refund`.

When using `purchase` we return the `receipt_id` and the `exchange_payment_id` returned values separated by a `|` (pipe) character so that a customer can have access to both and select which one they want to use in their downstream applications.