### PR TITLE
Add basic support for Bambora NA

### DIFF
--- a/lib/active_merchant/billing/gateways/bambora_na.rb
+++ b/lib/active_merchant/billing/gateways/bambora_na.rb
@@ -1,0 +1,162 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class BamboraNaGateway < Gateway
+      include Empty
+
+      self.live_url = 'https://api.na.bambora.com'
+
+      self.supported_countries = ['US', 'CA']
+      self.default_currency = 'USD'
+      self.money_format = :dollars
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover]
+
+      self.homepage_url = 'https://www.bambora.com/'
+      self.display_name = 'Bambora North America'
+
+      STANDARD_ERROR_CODE_MAPPING = {}
+
+      # TODO: add error code mapping and auth/capture/void/refund methods
+
+      def initialize(options={})
+        requires!(options, :merchant_id, :api_key)
+        super
+      end
+
+      def purchase(money, payment, options={})
+        post = {}
+        add_invoice(post, money, options)
+        add_payment(post, payment, 'sale')
+        add_address(post, payment, options)
+
+        commit('sale', post)
+      end
+
+      def store(credit_card, options = {})
+        post = {}
+        add_payment(post, credit_card, 'store')
+
+        commit('TokenRequest', post)
+      end
+
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript.
+          gsub(%r((Authorization: Passcode )\w+), '\1[FILTERED]').
+          gsub(/("number\\?":\\?")(\d*)/, '\1[FILTERED]').
+          gsub(/("cvd\\?":\\?")(\d*)/, '\1[FILTERED]')
+      end
+
+      private
+
+      def add_address(post, creditcard, options)
+        post[:billing] = {}
+        if address = options[:billing_address] || options[:address]
+          post[:billing][:address_line1] = address[:address1] if address[:address1]
+          post[:billing][:address_line2] = address[:address2] if address[:address2]
+          post[:billing][:city] = address[:city] if address[:city]
+          post[:billing][:province] = address[:state] if address[:state]
+          post[:billing][:postal_code] = address[:zip] if address[:zip]
+          post[:billing][:country] = address[:country] if address[:country]
+        end
+      end
+
+      def add_invoice(post, money, options)
+        post[:amount] = amount(money)
+        post[:payment_method] = 'card'
+        post[:order_number] = options[:order_id] unless empty?(options[:order_id])
+      end
+
+      def add_payment(post, payment, action = nil)
+        card = {}
+        card[:number] = payment.number
+        card[:expiry_month] = format(payment.month, :two_digits)
+        card[:expiry_year] = format(payment.year, :two_digits)
+
+        unless action == 'store'
+          card[:name] = payment.name
+          card[:cvd] = payment.verification_value
+          card[:complete] = (action != 'auth')
+        end
+
+        action == 'store' ? post.merge!(card) : post[:card] = card
+      end
+
+      def parse(body)
+        JSON.parse(body)
+      end
+
+      def headers
+        {
+          'Authorization' => "Passcode #{encoded_passcode}",
+          'Content-Type' => 'application/json'
+        }
+      end
+
+      def encoded_passcode
+        Base64.strict_encode64 "#{@options[:merchant_id]}:#{@options[:api_key]}"
+      end
+
+      def url(action)
+        endpoint = action == 'TokenRequest' ? 'scripts/tokenization/tokens' : 'v1/payments'
+        
+        "#{live_url}/#{endpoint}"
+      end
+
+      def commit(action, parameters)
+        begin
+          raw_response = ssl_post(url(action), parameters.to_json, headers)
+          body = parse(raw_response)
+          code = '200' # AM returns the response.body when http_status 200..300
+                       # so it's not available
+        rescue ResponseError => e
+          body = parse(e.response.body)
+          code = e.response.code
+        end
+        
+        Response.new(
+          success_from(code),
+          message_from(body),
+          body,
+          authorization: authorization_from(action, code, body),
+          test: test?,
+          error_code: error_code_from(body)
+        )
+
+      rescue JSON::ParserError
+        return unparsable_response(raw_response)
+      end
+
+      def success_from(http_status)
+        http_status == '200'
+      end
+
+      def message_from(response)
+        response['message']
+      end
+
+      def authorization_from(action, http_status, response)
+        if success_from(http_status) && action == 'sale'
+          [response['id'], response['auth_code']].join('|')
+        elsif success_from(http_status) && action == 'TokenRequest'
+          response['token']
+        end
+      end
+
+      def unparsable_response(raw_response)
+        message = "Invalid JSON response received from Bambora NA. Please contact support if you continue to receive this message."
+        message += "Support is available at https://help.na.bambora.com/hc/en-us/requests/new"
+        message += " (The raw response returned by the API was #{raw_response.inspect})"
+        return Response.new(false, message)
+      end
+
+      def error_code_from(response)
+        unless success_from(response)
+          # TODO: lookup error code for this response
+        end
+      end
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -36,6 +36,10 @@ axcessms:
 balanced:
   login: 'e1c5ad38d1c711e1b36c026ba7e239a9'
 
+bambora_na:
+  merchant_id: MERCHANT_ID
+  api_key: API_KEY
+
 # Bank Frick doesn't provide public testing data
 bank_frick:
   sender: sender-uuid

--- a/test/remote/gateways/remote_bambora_na_test.rb
+++ b/test/remote/gateways/remote_bambora_na_test.rb
@@ -1,0 +1,66 @@
+require 'test_helper'
+
+class RemoteBamboraNaTest < Test::Unit::TestCase
+  def setup
+    @gateway = BamboraNaGateway.new(fixtures(:bambora_na))
+
+    @amount = 100
+    @credit_card = credit_card('4030000010001234')
+    @credit_card_store = credit_card('4030000010001234', verification_value: nil)
+    @declined_card = credit_card('4003050500040005')
+    @options = {
+      billing_address: address,
+      description: 'Store Purchase',
+      order_id: SecureRandom.hex(10)
+    }
+  end
+
+  def test_successful_purchase
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_successful_purchase_with_more_options
+    options = {
+      order_id: '1',
+      ip: "127.0.0.1",
+      email: "joe@example.com"
+    }
+
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_failed_purchase
+    response = @gateway.purchase(@amount, @declined_card, @options)
+    assert_failure response
+    assert_equal 'DECLINE', response.message
+  end
+
+  def test_invalid_login
+    gateway = BamboraNaGateway.new(merchant_id: '', api_key: '')
+
+    response = gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_match %r{authentication failed}i, response.message
+  end
+
+  def test_successful_store
+    response = @gateway.store(@credit_card_store, @options)
+    assert_success response
+    assert_match /[-a-f0-9]+/, response.authorization
+  end
+
+  def test_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card.number, transcript)
+    assert_scrubbed(Base64.strict_encode64("#{@options[:merchant_id]}:#{@options[:api_key]}"), transcript)
+  end
+
+end

--- a/test/unit/gateways/bambora_na_test.rb
+++ b/test/unit/gateways/bambora_na_test.rb
@@ -1,0 +1,179 @@
+require 'test_helper'
+
+class BamboraNaTest < Test::Unit::TestCase
+  def setup
+    @gateway = BamboraNaGateway.new(merchant_id: 'login', api_key: 'password')
+    @credit_card = credit_card
+    @amount = 100
+
+    @options = {
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
+    }
+  end
+
+  def test_successful_purchase
+    @gateway.expects(:ssl_post).returns(successful_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+
+    assert_equal '10000050|TEST', response.authorization
+    assert_equal 'Approved', response.message
+    assert response.test?
+  end
+
+  def test_failed_purchase
+    @gateway.expects(:ssl_post).raises(ActiveMerchant::ResponseError.new(failed_purchase_response))
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal 'DECLINE', response.message
+  end
+
+  def test_scrub
+    assert @gateway.supports_scrubbing?
+    assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
+  end
+
+  def test_successful_store
+    @gateway.expects(:ssl_post).returns(successful_store_response)
+    
+    response = @gateway.store(@credit_card)
+    assert_success response
+    assert_equal 'a63-155e2ad3-3b1f-41b9-ae5f-85fb6870f958', response.authorization
+  end
+
+  private
+
+  def pre_scrubbed
+    %q(
+opening connection to api.na.bambora.com:443...
+opened
+starting SSL for api.na.bambora.com:443...
+SSL established
+<- "POST /v1/payments HTTP/1.1\r\nContent-Type: application/json\r\nAuthorization: Passcode c2Vrcml0LXNxdWlycmVs\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: api.na.bambora.com\r\nContent-Length: 346\r\n\r\n"
+<- "{\"amount\":\"1.00\",\"payment_method\":\"card\",\"order_number\":\"4b158d652109ebc82560\",\"card\":{\"number\":\"4030000010001234\",\"expiry_month\":\"09\",\"expiry_year\":\"19\",\"name\":\"Longbob Longsen\",\"cvd\":\"123\",\"complete\":true},\"billing\":{\"address_line1\":\"456 My Street\",\"address_line2\":\"Apt 1\",\"city\":\"Ottawa\",\"province\":\"ON\",\"postal_code\":\"K1C2N6\",\"country\":\"CA\"}}"
+-> "HTTP/1.1 200 OK\r\n"
+-> "Cache-Control: no-cache\r\n"
+-> "Pragma: no-cache\r\n"
+-> "Content-Type: application/json; charset=utf-8\r\n"
+-> "Expires: -1\r\n"
+-> "Server: Microsoft-IIS/8.5\r\n"
+-> "X-AspNet-Version: 4.0.30319\r\n"
+-> "X-Powered-By: ASP.NET\r\n"
+-> "Access-Control-Allow-Origin: *\r\n"
+-> "Access-Control-Allow-Headers: accept, origin, content-type\r\n"
+-> "X-UA-Compatible: IE=edge,chrome=1\r\n"
+-> "Date: Wed, 24 Jan 2018 00:49:44 GMT\r\n"
+-> "Connection: close\r\n"
+-> "Content-Length: 726\r\n"
+-> "\r\n"
+reading 726 bytes...
+-> "{\"id\":\"10000050\",\"authorizing_merchant_id\":293110000,\"approved\":\"1\",\"message_id\":\"1\",\"message\":\"Approved\",\"auth_code\":\"TEST\",\"created\":\"2018-01-23T19:49:44\",\"order_number\":\"4b158d652109ebc82560\",\"type\":\"P\",\"payment_method\":\"CC\",\"risk_score\":0.0,\"amount\":1.00,\"custom\":{\"ref1\":\"\",\"ref2\":\"\",\"ref3\":\"\",\"ref4\":\"\",\"ref5\":\"\"},\"card\":{\"card_type\":\"VI\",\"last_four\":\"1234\",\"address_match\":0,\"postal_result\":0,\"avs_result\":\"0\",\"cvd_result\":\"1\",\"avs\":{\"id\":\"N\",\"message\":\"Street address and Postal/ZIP do not match.\",\"processed\":true}},\"links\":[{\"rel\":\"void\",\"href\":\"https://api.na.bambora.com/v1/payments/10000050/void\",\"method\":\"POST\"},{\"rel\":\"return\",\"href\":\"https://api.na.bambora.com/v1/payments/10000050/returns\",\"method\":\"POST\"}]}"
+read 726 bytes
+Conn close
+    )
+  end
+
+  def post_scrubbed
+    %q(
+opening connection to api.na.bambora.com:443...
+opened
+starting SSL for api.na.bambora.com:443...
+SSL established
+<- "POST /v1/payments HTTP/1.1\r\nContent-Type: application/json\r\nAuthorization: Passcode [FILTERED]\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: api.na.bambora.com\r\nContent-Length: 346\r\n\r\n"
+<- "{\"amount\":\"1.00\",\"payment_method\":\"card\",\"order_number\":\"4b158d652109ebc82560\",\"card\":{\"number\":\"[FILTERED]\",\"expiry_month\":\"09\",\"expiry_year\":\"19\",\"name\":\"Longbob Longsen\",\"cvd\":\"[FILTERED]\",\"complete\":true},\"billing\":{\"address_line1\":\"456 My Street\",\"address_line2\":\"Apt 1\",\"city\":\"Ottawa\",\"province\":\"ON\",\"postal_code\":\"K1C2N6\",\"country\":\"CA\"}}"
+-> "HTTP/1.1 200 OK\r\n"
+-> "Cache-Control: no-cache\r\n"
+-> "Pragma: no-cache\r\n"
+-> "Content-Type: application/json; charset=utf-8\r\n"
+-> "Expires: -1\r\n"
+-> "Server: Microsoft-IIS/8.5\r\n"
+-> "X-AspNet-Version: 4.0.30319\r\n"
+-> "X-Powered-By: ASP.NET\r\n"
+-> "Access-Control-Allow-Origin: *\r\n"
+-> "Access-Control-Allow-Headers: accept, origin, content-type\r\n"
+-> "X-UA-Compatible: IE=edge,chrome=1\r\n"
+-> "Date: Wed, 24 Jan 2018 00:49:44 GMT\r\n"
+-> "Connection: close\r\n"
+-> "Content-Length: 726\r\n"
+-> "\r\n"
+reading 726 bytes...
+-> "{\"id\":\"10000050\",\"authorizing_merchant_id\":293110000,\"approved\":\"1\",\"message_id\":\"1\",\"message\":\"Approved\",\"auth_code\":\"TEST\",\"created\":\"2018-01-23T19:49:44\",\"order_number\":\"4b158d652109ebc82560\",\"type\":\"P\",\"payment_method\":\"CC\",\"risk_score\":0.0,\"amount\":1.00,\"custom\":{\"ref1\":\"\",\"ref2\":\"\",\"ref3\":\"\",\"ref4\":\"\",\"ref5\":\"\"},\"card\":{\"card_type\":\"VI\",\"last_four\":\"1234\",\"address_match\":0,\"postal_result\":0,\"avs_result\":\"0\",\"cvd_result\":\"1\",\"avs\":{\"id\":\"N\",\"message\":\"Street address and Postal/ZIP do not match.\",\"processed\":true}},\"links\":[{\"rel\":\"void\",\"href\":\"https://api.na.bambora.com/v1/payments/10000050/void\",\"method\":\"POST\"},{\"rel\":\"return\",\"href\":\"https://api.na.bambora.com/v1/payments/10000050/returns\",\"method\":\"POST\"}]}"
+read 726 bytes
+Conn close
+    )
+  end
+
+  def successful_purchase_response
+    '{
+      "amount": 1.0,
+      "approved": "1",
+      "auth_code": "TEST",
+      "authorizing_merchant_id": 293110000,
+      "card": {
+          "address_match": 0,
+          "avs": {
+              "id": "N",
+              "message": "Street address and Postal/ZIP do not match.",
+              "processed": true
+          },
+          "avs_result": "0",
+          "card_type": "VI",
+          "cvd_result": "1",
+          "last_four": "1234",
+          "postal_result": 0
+      },
+      "created": "2018-01-23T19:49:44",
+      "custom": {
+          "ref1": "",
+          "ref2": "",
+          "ref3": "",
+          "ref4": "",
+          "ref5": ""
+      },
+      "id": "10000050",
+      "links": [
+          {
+              "href": "https://api.na.bambora.com/v1/payments/10000050/void",
+              "method": "POST",
+              "rel": "void"
+          },
+          {
+              "href": "https://api.na.bambora.com/v1/payments/10000050/returns",
+              "method": "POST",
+              "rel": "return"
+          }
+      ],
+      "message": "Approved",
+      "message_id": "1",
+      "order_number": "4b158d652109ebc82560",
+      "payment_method": "CC",
+      "risk_score": 0.0,
+      "type": "P"
+    }'
+  end
+
+  def failed_purchase_response
+    body = '{
+      "code": 7,
+      "category": 1,
+      "message": "DECLINE",
+      "reference": ""
+    }'
+
+    MockResponse.failed(body)
+  end
+
+  def successful_store_response
+    '{
+      "token": "a63-155e2ad3-3b1f-41b9-ae5f-85fb6870f958",
+      "code": 1,
+      "version": 1,
+      "message": ""
+    }'
+  end
+
+end


### PR DESCRIPTION
Bambora North America has a different API than Beamstream (old XML/SOAP API) or other regions.

This implements a basic support (just `purchase` and `store` methods).

There's still more todo to finish it to be a proper ActiveMerchant implementation, i.e. use the error code mapping to return the right ActiveMerchant errors and also add the `authorisation|capture|void|refund` methods.

```
Loaded suite test/remote/gateways/remote_bambora_na_test
Started
......

Finished in 12.076706 seconds.
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
6 tests, 12 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
0.50 tests/s, 0.99 assertions/s

Loaded suite test/unit/gateways/bambora_na_test
Started
....

Finished in 0.002458 seconds.
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
4 tests, 13 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1627.34 tests/s, 5288.85 assertions/s
```