### PR TITLE
Add previously undocumented options to purchase

### DIFF
--- a/lib/active_merchant/billing/gateways/mobilexpress.rb
+++ b/lib/active_merchant/billing/gateways/mobilexpress.rb
@@ -45,6 +45,8 @@ module ActiveMerchant #:nodoc:
             add_authentication(xml, options)
             add_invoice(xml, money, options)
             add_payment(xml, payment)
+            add_customer_data(xml, options)
+            add_transaction(xml, options)
           end
         end
 
@@ -97,9 +99,13 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_customer_data(xml, options)
-        xml.CustomerID options[:customer_id]
+        xml.CustomerID options[:customer_id] unless empty?(options[:customer_id])
         xml.CustomerName options[:customer_name] unless empty?(options[:customer_name])
         xml.ClientIP options[:ip] unless empty?(options[:ip])
+      end
+
+      def add_transaction(xml, options)
+        xml.TransactionId (options[:order_id] || SecureRandom.hex(10))
       end
 
       def add_token_store(xml, card_token)

--- a/test/remote/gateways/remote_mobilexpress_test.rb
+++ b/test/remote/gateways/remote_mobilexpress_test.rb
@@ -22,9 +22,11 @@ class RemoteMobilexpressTest < Test::Unit::TestCase
 
   def test_successful_purchase_with_more_options
     options = {
-      order_id: '1',
       ip: "127.0.0.1",
-      email: "joe@example.com"
+      email: "joe@example.com",
+      customer_id: SecureRandom.uuid,
+      customer_name: 'Bob Longson',
+      ip: '127.0.0.1'
     }
 
     response = @gateway.purchase(@amount, @credit_card, options)


### PR DESCRIPTION
`ProcessPaymentWithCard` now adds a unique transaction_id if `order_id` is not passed as options and can also add customer data which was previously undocumented.

This should address the issues raised by our customers using Mobilexpress that wanted those details logged with the purchase transactions.