### PR TITLE
Only send SideCar when option is present

### DIFF
--- a/lib/active_merchant/billing/gateways/payment_solutions.rb
+++ b/lib/active_merchant/billing/gateways/payment_solutions.rb
@@ -122,6 +122,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_sidecar(xml, options = {})
+        return if empty?(options[:sidecar_value])
         xml['d4p1'].SideCar do
           xml['d4p1'].NameValuePair do
             xml['d4p1'].Name 'field_c6'


### PR DESCRIPTION
Despite the fact that initially the request was to send the `Value` empty, we've been requested to only send the `SideCar` when the value is present and non nil.