### PR TITLE
Silence deprecation notices in AuthorizeNet

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net_arb.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_arb.rb
@@ -57,7 +57,6 @@ module ActiveMerchant #:nodoc:
       # * <tt>:test</tt> -- +true+ or +false+. If true, perform transactions against the test server.
       #   Otherwise, perform transactions against the production server.
       def initialize(options = {})
-        ActiveMerchant.deprecated "ARB functionality in ActiveMerchant is deprecated and will be removed in a future version. Please contact the ActiveMerchant maintainers if you have an interest in taking ownership of a separate gem that continues support for it."
         requires!(options, :login, :password)
         super
       end

--- a/test/unit/gateways/authorize_net_arb_test.rb
+++ b/test/unit/gateways/authorize_net_arb_test.rb
@@ -4,7 +4,6 @@ class AuthorizeNetArbTest < Test::Unit::TestCase
   include CommStub
 
   def setup
-    ActiveMerchant.expects(:deprecated).with("ARB functionality in ActiveMerchant is deprecated and will be removed in a future version. Please contact the ActiveMerchant maintainers if you have an interest in taking ownership of a separate gem that continues support for it.")
     @gateway = AuthorizeNetArbGateway.new(
       :login => 'X',
       :password => 'Y'


### PR DESCRIPTION
Unnecessary since we now maintain our own fork (we've added plenty of gateways, etc) and it's extremely unlikely that our fork will be merged upstream.