### PR TITLE
Permit Bambora NA creation of profiles on store

### DIFF
--- a/test/remote/gateways/remote_bambora_na_test.rb
+++ b/test/remote/gateways/remote_bambora_na_test.rb
@@ -53,6 +53,17 @@ class RemoteBamboraNaTest < Test::Unit::TestCase
     assert_match /[-a-f0-9]+/, response.authorization
   end
 
+  def test_successful_store_profile
+    more_options = {
+      email: "joe@example.com",
+      create_profile: true
+    }
+    options_with_profile = @options.merge(more_options)
+    response = @gateway.store(@credit_card_store, options_with_profile)
+    assert_success response
+    assert_match /[-a-f0-9]+/, response.authorization
+  end
+
   def test_transcript_scrubbing
     transcript = capture_transcript(@gateway) do
       @gateway.purchase(@amount, @credit_card, @options)

--- a/test/unit/gateways/bambora_na_test.rb
+++ b/test/unit/gateways/bambora_na_test.rb
@@ -45,6 +45,19 @@ class BamboraNaTest < Test::Unit::TestCase
     assert_equal 'a63-155e2ad3-3b1f-41b9-ae5f-85fb6870f958', response.authorization
   end
 
+  def test_successful_store_profile
+    @gateway.expects(:ssl_post).returns(successful_store_profile_response)
+
+    more_options = @options.merge({
+      create_profile: true,
+      email: 'joe@example.com'
+    })
+    
+    response = @gateway.store(@credit_card, more_options)
+    assert_success response
+    assert_equal '7d406307bedB4C1089947752D2F5AB93', response.authorization
+  end
+
   private
 
   def pre_scrubbed
@@ -176,4 +189,11 @@ Conn close
     }'
   end
 
+  def successful_store_profile_response
+    '{
+      "code": 1,
+      "message": "Operation Successful",
+      "customer_code": "7d406307bedB4C1089947752D2F5AB93"
+    }'
+  end
 end


### PR DESCRIPTION
This change introduces a small but important change in the `store` method for the Bambora NA gateway. It adds support for creating payment profiles using a card instead of calling the tokenization. The profiles will return the `customer_code` as the `authorization` instead of the `token` from the Tokenization API. In order to use it, you need to pass an option called `create_profile`.

Note: the profiles API requires a different set of data in the billing address, namely the `name`, `phone_number` and `email_address` are all mandatory.

```
Loaded suite test/unit/gateways/bambora_na_test
Started
.....

Finished in 0.004281 seconds.
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
5 tests, 16 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1167.95 tests/s, 3737.44 assertions/s
```

```
Loaded suite test/remote/gateways/remote_bambora_na_test
Started
.......

Finished in 8.454979 seconds.
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
7 tests, 14 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
0.83 tests/s, 1.66 assertions/s
```