### PR TITLE
Supports custom merchantCode in paymentService

### DIFF
--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -128,7 +128,7 @@ module ActiveMerchant #:nodoc:
         xml = Builder::XmlMarkup.new :indent => 2
         xml.instruct! :xml, :encoding => 'UTF-8'
         xml.declare! :DOCTYPE, :paymentService, :PUBLIC, "-//WorldPay//DTD WorldPay PaymentService v1//EN", "http://dtd.worldpay.com/paymentService_v1.dtd"
-        xml.tag! 'paymentService', 'version' => "1.4", 'merchantCode' => @options[:login] do
+        xml.tag! 'paymentService', 'version' => "1.4", 'merchantCode' => (@options[:merchant_code] ? @options[:merchant_code] : @options[:login]) do
           yield xml
         end
         xml.target!


### PR DESCRIPTION
Depending on the customer’s configuration of the merchant facilities, WorldPay could require the `merchantCode` in the top level XML tag `paymentService` to be a different `merchant_code` that’s not the `login`. This change adds support for this. Note: the `merchant_code` needs to be passed to the initialiser of the `@gateway` so it’s added to the `@options` and not just on the `options` parameter of a `purchase` method, say …

```
$ bundle exec ruby -Itest test/unit/gateways/worldpay_test.rb
Loaded suite test/unit/gateways/worldpay_test
Started
.....................................

Finished in 0.196618 seconds.
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
37 tests, 210 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
188.18 tests/s, 1068.06 assertions/s
```

and remote tests

```
$ bundle exec ruby -Itest test/remote/gateways/remote_worldpay_test.rb
Loaded suite test/remote/gateways/remote_worldpay_test
Started
Finished in 72.670442 seconds.
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
23 tests, 66 assertions, 6 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
73.913% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
0.32 tests/s, 0.91 assertions/s
```

note: of the 6 failures, all return `"Order not ready”` and the one from `test_successful_credit_on_cft_gateway` as we don’t have proper credentials for the CFT gateway.