### PR TITLE
BBPS now needs full URL instead of just hostname

### DIFF
--- a/lib/active_merchant/billing/gateways/blackbaud_bbps.rb
+++ b/lib/active_merchant/billing/gateways/blackbaud_bbps.rb
@@ -20,7 +20,7 @@ module ActiveMerchant #:nodoc:
       SOAP_XMLNS = { xmlns: SOAP_ACTION_NS }.freeze
 
       def initialize(options = {})
-        requires!(options, :hostname, :username, :password)
+        requires!(options, :url, :username, :password)
         super
       end
 
@@ -101,14 +101,24 @@ module ActiveMerchant #:nodoc:
       def headers(action)
         {
           'Content-Type'    => 'text/xml; charset=utf-8',
-          'Host'            => @options[:hostname],
+          'Host'            => hostname,
           'SOAPAction'      => "#{SOAP_ACTION_NS}/#{action}",
           'Authorization'   => "Basic #{basic_auth}"
         }
       end
 
+      def hostname
+        URI.parse(normalised_url).host
+      end
+
+      def normalised_url
+        # note: URI will throw an exception if `@options[:url]` does not contain
+        # the protocol so we do this naive dance
+        @options[:url].start_with?('http') ? @options[:url] : "https://#{@options[:url]}"
+      end
+
       def url
-        "https://#{@options[:hostname].strip}/bbAppFx/AppFxWebService.asmx"
+        normalised_url.strip
       end
 
       def commit(action, xml)

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -81,7 +81,7 @@ bit_pay:
   api_key: 'rKrahSl7WRrYeKRUhGzbvW3nBzo0jG4FPaL8uPYaoPk'
 
 blackbaud_bbps:
-  hostname: hostname_from_blackbaud
+  url: full_url_api
   username: username
   password: password
 

--- a/test/remote/gateways/remote_blackbaud_bbps_test.rb
+++ b/test/remote/gateways/remote_blackbaud_bbps_test.rb
@@ -8,6 +8,7 @@ class RemoteBlackbaudBbpsTest < Test::Unit::TestCase
     @credit_card = credit_card('4000100011112224')
     @declined_card = credit_card('1111111111111111')
     @options = {
+      database_to_use: '27308T',
       client_app: 'Evergiving Test'
     }
   end

--- a/test/unit/gateways/blackbaud_bbps_test.rb
+++ b/test/unit/gateways/blackbaud_bbps_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class BlackbaudBbpsTest < Test::Unit::TestCase
   def setup
-    @gateway = BlackbaudBbpsGateway.new(hostname: 'foo', username: 'bar', password: 'sekrit')
+    @gateway = BlackbaudBbpsGateway.new(url: 'foo', username: 'bar', password: 'sekrit')
     @credit_card = credit_card
 
     @options = {


### PR DESCRIPTION
**breaking change**

Blackbaud has instances that do not use the standard path so we need to support passing a full URL (eg: `https://foo.blackbaudhosting.com/XXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX/AppFxWebService.asmx`) so the new mandatory parameter has been renamed to `url` from `hostname` to clearly indicate the purpose.

```
$ ruby -Itest test/unit/gateways/blackbaud_bbps_test.rb
Loaded suite test/unit/gateways/blackbaud_bbps_test
Started
...

Finished in 0.04067 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
3 tests, 8 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
73.76 tests/s, 196.71 assertions/s
```

and

```
$ ruby -Itest test/remote/gateways/remote_blackbaud_bbps_test.rb
Loaded suite test/remote/gateways/remote_blackbaud_bbps_test
Started
....

Finished in 0.343984 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
4 tests, 8 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
11.63 tests/s, 23.26 assertions/s
```