### PR TITLE
Add support for sending `ms` in Jackson River

### DIFF
--- a/lib/active_merchant/billing/gateways/jackson_river.rb
+++ b/lib/active_merchant/billing/gateways/jackson_river.rb
@@ -21,6 +21,7 @@ module ActiveMerchant #:nodoc:
         add_payment(post, payment)
         add_address(post, options)
         add_customer_data(post, options)
+        add_metadata(post, options)
 
         commit('sale', post, options)
       end
@@ -64,6 +65,10 @@ module ActiveMerchant #:nodoc:
         post[:card_number] = payment.number
         post[:card_expiration_month] = payment.month
         post[:card_expiration_year]  = format(payment.year, :four_digits)
+      end
+
+      def add_metadata(post, options = {})
+        post[:ms] = options[:market_source] if options[:market_source]
       end
 
       def parse(body)

--- a/test/remote/gateways/remote_jackson_river_test.rb
+++ b/test/remote/gateways/remote_jackson_river_test.rb
@@ -11,7 +11,8 @@ class RemoteJacksonRiverTest < Test::Unit::TestCase
       last_name: 'Longsen',
       billing_address: address,
       description: 'Store Purchase',
-      form_id: 34467
+      form_id: 34467,
+      market_source: 'FooBar_MarketSource'
     }
   end
 


### PR DESCRIPTION
Optional parameter called `market_source` (sent as `ms`) for Jackson River

```
$ bundle exec ruby -Itest test/remote/gateways/remote_jackson_river_test.rb
Loaded suite test/remote/gateways/remote_jackson_river_test
Started
....

Finished in 8.505442 seconds.
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
4 tests, 9 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
0.47 tests/s, 1.06 assertions/s

$ bundle exec ruby -Itest test/unit/gateways/jackson_river_test.rb
Loaded suite test/unit/gateways/jackson_river_test
Started
...

Finished in 0.002356 seconds.
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
3 tests, 9 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1273.34 tests/s, 3820.03 assertions/s
```