### PR TITLE
Relax nokogiri version requirement

### DIFF
--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency('activesupport', '>= 3.2.14', '< 6.x')
   s.add_dependency('i18n', '>= 0.6.9')
   s.add_dependency('builder', '>= 2.1.2', '< 4.0.0')
-  s.add_dependency('nokogiri', "~> 1.4")
+  s.add_dependency('nokogiri', "~> 1")
 
   s.add_development_dependency('rake')
   s.add_development_dependency('test-unit', '~> 3')


### PR DESCRIPTION
We're picking a nokogiri version in waysact/Gemfile anyway and so this
overly strict requirement only gets in the way.

This change simplifies our upgrade to Rails 5 somewhat.