### PR TITLE
Add flo2cashRest gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/flo2cash_rest.rb
+++ b/lib/active_merchant/billing/gateways/flo2cash_rest.rb
@@ -339,7 +339,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_customer_resume(post, options)
-        post[:initiatedBy] = options[:initiatedBy]
+        post[:initiatedBy] = options[:initiated_by]
         post[:receiptRecipient] = options[:email]
       end
 
@@ -454,7 +454,6 @@ module ActiveMerchant #:nodoc:
       def add_merchant(post, options)
         post[:merchant]  = {
           'id' => options[:merchant_id] || @merchant_id
-          # 'subAccount' => options[:sub_account_id] || @sub_account_id
         }
       end
 
@@ -486,11 +485,11 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_debit_card_references(post, options)
-        post[:statementReference1] = options[:statementReference1]
-        post[:statementReference2] = options[:statementReference2]
-        post[:merchantReference1] = options[:merchantReference1]
-        post[:merchantReference2] = options[:merchantReference2]
-        post[:merchantReference3] = options[:merchantReference3]
+        post[:statementReference1] = options[:statement_reference_1]
+        post[:statementReference2] = options[:statement_reference_2]
+        post[:merchantReference1] = options[:merchant_reference_1]
+        post[:merchantReference2] = options[:merchant_reference_2]
+        post[:merchantReference3] = options[:merchant_reference_3]
       end
 
       # For Recurring Plans Flo2Cash manages charging and retries on defined

--- a/lib/active_merchant/billing/gateways/flo2cash_rest.rb
+++ b/lib/active_merchant/billing/gateways/flo2cash_rest.rb
@@ -184,6 +184,8 @@ module ActiveMerchant #:nodoc:
         commit(:post, :create_card_plan, post, options)
       end
 
+      alias_method :recurring, :create_card_plan
+
       # Create a new Direct Debit Plan
       #
       # recurring payments with their bank account numbers
@@ -228,6 +230,8 @@ module ActiveMerchant #:nodoc:
         commit(:post, :create_direct_debit_plan, post, options)
       end
 
+      alias_method :recurring_debit, :create_card_plan
+
       def supports_scrubbing?
         true
       end
@@ -241,19 +245,19 @@ module ActiveMerchant #:nodoc:
 
       # Returns a Payment resource
       #
-      def retrieve_card_plan(plan_id, options)
+      def retrieve_card_plan(plan_id, options={})
         commit(:get, :retrieve_card_plan, { plan_id: plan_id }, options)
       end
 
       # Returns a Payment resource
       #
-      def retrieve_card_payment(payment_id, options)
+      def retrieve_card_payment(payment_id, options={})
         commit(:get, :retrieve_card_payment, { payment_id: payment_id }, options)
       end
 
       # Returns a Direct Debit Plan
       #
-      def retrieve_direct_debit_plan(plan_id, options)
+      def retrieve_direct_debit_plan(plan_id, options={})
         commit(:get, :retrieve_direct_debit_plan, { plan_id: plan_id }, options)
       end
 
@@ -267,7 +271,7 @@ module ActiveMerchant #:nodoc:
       #   + Active can only be applied to suspended plans
       #   + Suspended can only be applied to active plans
       #
-      def update_card_plan(plan_id, status, options)
+      def update_card_plan(plan_id, status, options={})
         params = { plan_id: plan_id, status: status }
         commit(:put, :update_card_plan, params, options)
       end
@@ -282,7 +286,7 @@ module ActiveMerchant #:nodoc:
       #   + Active can only be applied to suspended plans
       #   + Suspended can only be applied to active plans
       #
-      def update_direct_debit_plan(plan_id, status, options)
+      def update_direct_debit_plan(plan_id, status, options={})
         params = { plan_id: plan_id, status: status }
         commit(:put, :update_direct_debit_plan, params, options)
       end

--- a/lib/active_merchant/billing/gateways/flo2cash_rest.rb
+++ b/lib/active_merchant/billing/gateways/flo2cash_rest.rb
@@ -505,18 +505,18 @@ module ActiveMerchant #:nodoc:
       #
       # ==== Options
       #
-      # * <tt>retry_preference_perform</tt> -- true | false
-      # * <tt>retry_preference_frequency</tt> Number of days in between attempts
-      # * <tt>retry_preference_max_retry</tt> Number of attempts (max value 7)
+      # * <tt>retry_payments</tt> -- true | false
+      # * <tt>retry_day_interval</tt> Number of days in between attempts
+      # * <tt>retry_max_amount</tt> Number of attempts (max value 7)
       #
       # Based on the chosen parameters, retires are attempted every calendar day,
       # irrespective of the weekend or a public holiday.
       #
       def add_retry_preferences(post, options)
         post[:retryPreferences] = {
-          'perform' => options[:retry_preference_perform] || false,
-          'frequencyInDays' => options[:retry_preference_frequency] || 1,
-          'maxAttempts' => options[:retry_preference_max_retry] || 7
+          'perform' => options[:retry_payments] || false,
+          'frequencyInDays' => options[:retry_day_interval] || 1,
+          'maxAttempts' => options[:retry_max_amount] || 7
         }
       end
 

--- a/lib/active_merchant/billing/gateways/flo2cash_rest.rb
+++ b/lib/active_merchant/billing/gateways/flo2cash_rest.rb
@@ -1,0 +1,595 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+
+    # For more information on the flo2cash visit {Flo2Cash}[https://flo2cash.com/nz]
+    #
+    # ==== Automated Recurring Billing (ARB)
+    #
+    # Before using the Recurring Payments service, you first need to make sure
+    # that you have at least one of the Recurring Payments channel enabled for
+    # your account
+    #
+    # Recurring Payments supports two different types of recurring payments
+    # * `Recurring Card Payments` which allow you to set up customer on
+    # recurring payments with their credit cards.
+    # * `Recurring Direct Debits` which allow you to set up customers on
+    # recurring payments with their bank account numbers.
+    #
+    class Flo2cashRestGateway < Gateway
+      self.test_url = 'https://sandbox.flo2cash.com/api'
+      self.live_url = 'https://secure.flo2cash.co.nz/web2pay/'
+
+      self.supported_countries = ['NZ']
+      self.default_currency = 'NZD'
+      self.supported_cardtypes = [:visa, :master, :american_express, :diners_club]
+
+      self.homepage_url = 'http://www.flo2cash.co.nz/'
+      self.display_name = 'Flo2Cash'
+
+      # Errors Codes from flo2Cash
+      #
+      #   05  Declined – Bank declined
+      #   10  Declined – Bank error
+      #   51  Declined – Insufficient funds
+      #   54  Declined – Expired card
+      #   68  Failed – No reply from bank
+      #
+      STANDARD_ERROR_CODE_MAPPING = {
+        '05' => STANDARD_ERROR_CODE[:processing_error],
+        '10' => STANDARD_ERROR_CODE[:processing_error],
+        '51' => STANDARD_ERROR_CODE[:card_declined],
+        '54' => STANDARD_ERROR_CODE[:expired_card],
+        '68' => STANDARD_ERROR_CODE[:processing_error],
+      }
+
+      BRAND_MAP = {
+        "visa" => "VISA",
+        "master" => "MC",
+        "american_express" => "AMEX",
+        "diners_club" => "DINERS"
+      }
+
+      CLIENT_ERROR_REGEX = /^4\d\d/
+
+      # The following are the response statuses from flo2cash to each endpoint
+      #
+      # If a transaction results in a decline due to reasons like card expired
+      # or insufficient funds, the transaction will be marked as Failed
+      #
+      # PAYMENT_STATUSES = %w(successful declined blocked failed unknown)
+      # CARD_PLAN_STATUSES = %w(active suspended ended cancelled)
+      # DIRECT_DEBIT_PLAN_STATUSES = %w(pending-approval active suspended ended cancelled)
+      # DIRECT_DEBIT_STATUSES = %w(scheduled processing successful dishonoured failed)
+
+      SUCCESS_STATUSES = %w(successful scheduled processing active cancelled pending-approval)
+
+      ACTION_URL_MAP = {
+        store: 'cardTokens',
+        purchase: '/payments',
+        refund: "/payments/%{payment_id}/refunds",
+        create_card_plan: '/cardplans',
+        create_direct_debit_plan: "/directdebitplans",
+        update_card_plan: "/cardplans/%{plan_id}/status",
+        update_direct_debit_plan: "/directdebitplans/%{plan_id}/status",
+        retrieve_card_plan: "/cardplans/%{plan_id}",
+        retrieve_card_payment: "/payments/%{payment_id}",
+        retrieve_direct_debit_plan: "/directdebitplans/%{plan_id}",
+      }
+
+      # Creates a new Flo2cachRest gateway
+      #
+      # The gateway requires a +merchant_id+ and a +api_key+ key be passed in
+      # the +options+ hash.
+      #
+      # ==== Options
+      #
+      # * <tt>:merchant_id</tt> -- The Flo2Cash Merchant ID (REQUIRED)
+      # * <tt>:api_key</tt> -- The Flo2Cash API key (REQUIRED)
+      #
+      def initialize(options = {})
+        requires!(options, :merchant_id, :api_key)
+        super
+      end
+
+      # Process Payment
+      #
+      def purchase(money, payment_method, options={})
+        post = {}
+        add_type(post, 'purchase')
+        add_channel(post, options)
+        add_invoice(post, money, options)
+        add_customer_resume(post, options)
+        add_references(post, options)
+        add_device_info(post, options)
+        add_geolocation(post, options)
+
+        token = retrieve_token(payment_method, options)
+        add_payment_method(post, options, token)
+
+        commit(:post, :purchase, post, options)
+      end
+
+      # Store the card and returns card token
+      #
+      def store(card, options)
+        post = {}
+        add_merchant(post, options)
+        add_unique_reference(post, options)
+        add_card_data(post, card)
+
+        commit(:post, :store, post, options)
+      end
+
+      # Refund a Card Payment
+      #
+      def refund(money, payment_id, options={})
+        post = { payment_id: payment_id }
+        add_amount(post, money)
+        add_references(post, options)
+        add_customer_resume(post, options)
+        add_device_info(post, options)
+        add_geolocation(post, options)
+
+        commit(:post, :refund, post, options)
+      end
+
+      # Create a new Card Plan
+      #
+      # These are self managed plans, where a plan is created for a customer
+      # with frequency and amount. Flo2Cash manages charging and retries at
+      # defined intervals
+      #
+      # ==== Parameters
+      #
+      # * <tt>token</tt> -- Card token
+      # * <tt>options</tt> -- hash of options
+      #
+      # ==== Options
+      #
+      # * <tt>:start_date</tt> is a string that tells the gateway when to start the rebill. (REQUIRED)
+      # * <tt>:type</tt> recurring | instalment (REQUIRED)
+      # * <tt>:amount</tt> Amount to rebill (REQUIRED)
+      # * <tt>:total_amount</tt> Amount to rebill (REQUIRED if type is instalment)
+      # + recurring, customer agrees to pay a fixed amount every defined frequency
+      # + instalment, divide the total amount you want to charge your customer into equal instalments.
+      # * <tt>frequency</tt>: one of { daily | weekly | fortnightly | 4-weekly | 8-weekly | 12-weekly |
+      # monthly | 2-monthly | 3-monthly | 6-monthly | 12-monthly }
+      # * <tt>:instalment_fail_option</tt> one of { none | add-to-next | add-to-last | add-at-end }
+      # * <tt>:paymentMethod</tt> A hash containeing the payment <tt>:type</tt> of the payment method and
+      # the <tt>:token</tt> or <tt>:iframe</tt> values depending of <tt>:type</tt>
+      # * <tt>:payer</tt> A hash containing customer information where <tt>:email</tt> is required
+      #
+      def create_card_plan(token, options)
+        post = {}
+        post[:startDate] = options[:start_date] || Date.today.at_beginning_of_month.next_month
+        add_type(post, options[:type] || 'recurring')
+        add_payment_method(post, options, token)
+        add_frequency(post, options)
+        add_customer_data(post, options)
+        add_address(post, options[:address])
+        add_invoice(post, options[:amount], options)
+        add_references(post, options)
+        add_merchant(post, options)
+        add_initial_payment(post, options)
+        add_retry_preferences(post, options)
+
+        commit(:post, :create_card_plan, post, options)
+      end
+
+      # Create a new Direct Debit Plan
+      #
+      # recurring payments with their bank account numbers
+      #
+      # ==== Parameters
+      #
+      # * <tt>token</tt> -- Card token
+      # * <tt>options</tt> -- hash of options
+      #
+      # ==== Options
+      #
+      # * <tt>:start_date</tt> is a string that tells the gateway when to start the rebill. (REQUIRED)
+      # * <tt>:type</tt> recurring | instalment | per-invoice (REQUIRED)
+      # * <tt>:amount</tt> Amount to rebill (REQUIRED)
+      # * <tt>:total_amount</tt> Amount to rebill (REQUIRED if type is instalment)
+      # * <tt>initial_date</tt> -- Initial payment date
+      # * <tt>intital_amount</tt> -- Amount to bill
+      # * <tt>frequency</tt>: one of { daily | weekly | fortnightly | 4-weekly | 8-weekly | 12-weekly |
+      # monthly | 2-monthly | 3-monthly | 6-monthly | 12-monthly } (NOT REQUIRED WHEN type per-invoice)
+      # * <tt>:signup_type</tt> one of { ivr | paper } (REQUIRED)
+      # * <tt>:payer</tt> A hash containing customer information where <tt>:email</tt> is required
+      # * <tt>bank_name</tt> -- Bank Name (REQUIRED) (< 50 chars)
+      # * <tt>account_name</tt> -- Account Holder name (REQUIRED) (< 20 chars)
+      # * <tt>account_number</tt> -- valid account number for merchants country
+      #
+      def create_direct_debit_plan(options)
+        post = {}
+        post[:startDate] = options[:start_date] || Date.today.at_beginning_of_month.next_month
+        post[:signupType] = options[:signup_type] || 'paper'
+
+        add_type(post, options[:type] || 'recurring') # recurring | instalment | per-invoice
+        add_frequency(post, options)
+        add_invoice(post, options[:amount], options)
+        add_debit_card_references(post, options)
+        add_merchant(post, options)
+        add_initial_payment(post, options)
+        add_retry_preferences(post, options)
+        add_customer_data(post, options)
+        add_address(post, options[:address])
+        add_bank_details(post, options)
+
+        commit(:post, :create_direct_debit_plan, post, options)
+      end
+
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript.
+          gsub(/(Authorization: Basic )\w+/, '\1[FILTERED]').
+          gsub(/(merchant\\?\\?\\?":{\\?\\?\\?"id\\?\\?\\?":)(\d+)/, '\1[FILTERED]').
+          gsub(/(card\\?\\?\\?":{\\?\\?\\?"number\\?\\?\\?":\\?\\?\\?")(\d+)/, '\1[FILTERED]')
+      end
+
+      # Returns a Payment resource
+      #
+      def retrieve_card_plan(plan_id, options)
+        commit(:get, :retrieve_card_plan, { plan_id: plan_id }, options)
+      end
+
+      # Returns a Payment resource
+      #
+      def retrieve_card_payment(payment_id, options)
+        commit(:get, :retrieve_card_payment, { payment_id: payment_id }, options)
+      end
+
+      # Returns a Direct Debit Plan
+      #
+      def retrieve_direct_debit_plan(plan_id, options)
+        commit(:get, :retrieve_direct_debit_plan, { plan_id: plan_id }, options)
+      end
+
+      # Update status of a Card Plan +plan_id+ if possible
+      #
+      # ==== Parameters
+      #
+      # * <tt>plan_id</tt> -- The identifier of Card Plan to change.
+      # * <tt>status</tt> -- can be "active | cancelled | suspended"
+      #   + Cancelled can only be applied to active/suspended plans
+      #   + Active can only be applied to suspended plans
+      #   + Suspended can only be applied to active plans
+      #
+      def update_card_plan(plan_id, status, options)
+        params = { plan_id: plan_id, status: status }
+        commit(:put, :update_card_plan, params, options)
+      end
+
+      # Update status of Direct Debit Plan +plan_id+ if possible
+      #
+      # ==== Parameters
+      #
+      # * <tt>plan_id</tt> -- The identifier of Direct Debit Plan to change.
+      # * <tt>status</tt> -- can be "cancelled | active | suspended"
+      #   + Cancelled can only be applied to active/suspended plans
+      #   + Active can only be applied to suspended plans
+      #   + Suspended can only be applied to active plans
+      #
+      def update_direct_debit_plan(plan_id, status, options)
+        params = { plan_id: plan_id, status: status }
+        commit(:put, :update_direct_debit_plan, params, options)
+      end
+
+      private
+
+      def commit(verb, action, params, options={})
+        begin
+          raw_response = ssl_request(verb, url(action, params), post_data(verb, params), headers(options))
+
+          response = parse(raw_response)
+          succeeded = success_from(response)
+        rescue ActiveMerchant::ResponseError => e
+          raise if e.response.code !~ CLIENT_ERROR_REGEX
+
+          response = parse(e.response.body)
+          succeeded = false
+        end
+
+        Response.new(
+          succeeded,
+          message_from(succeeded, response),
+          response,
+          authorization: authorization_from(action, response),
+          error_code: error_code_from(succeeded, response),
+          test: test?
+        )
+      end
+
+      def headers(options={})
+        {
+          'Content-Type' => 'application/json',
+          'Authorization' => "Basic #{options[:api_key]}"
+        }
+      end
+
+      def parse(body)
+        JSON.parse(body)
+      end
+
+      def success_from(response)
+        !response.key?('status') || SUCCESS_STATUSES.include?(response['status'])
+      end
+
+      def message_from(succeeded, response)
+        succeeded ? 'Succeeded' : error_code_from(false, response)
+      end
+
+      # Returns a card token
+      #
+      # ==== Options
+      #
+      # * <tt>payment_method</tt> -- The instrument to charge.
+      # * <tt>options</tt> -- A hash of parameters.
+      #
+      def retrieve_token(payment_method, options)
+        if payment_method.is_a?(String)
+          payment_method
+        else
+          store(payment_method, options).authorization
+        end
+      end
+
+      def add_customer_resume(post, options)
+        post[:initiatedBy] = options[:initiatedBy]
+        post[:receiptRecipient] = options[:email]
+      end
+
+      def add_customer_data(post, options)
+        post[:payer] = {
+          companyName: options[:company_name],
+          title: options[:title],
+          firstNames: options[:first_name],
+          lastName: options[:last_name],
+          dateOfBirth: options[:dob],
+          telephoneHome: options[:home_phone],
+          telephoneWork: options[:work_phone],
+          telephoneMobile: options[:mob_phone],
+          fax: options[:fax],
+          email: options[:email]
+        }
+
+        add_references(post, options)
+      end
+
+      def add_device_info(post, options)
+        post[:device] = {
+          id: options[:device_id],
+          description: options[:device_description]
+        }
+      end
+
+      def add_address(post, options)
+        post[:payer].merge({
+          address1: options.try(:[], :address1),
+          address2: options.try(:[], :address2),
+          address3: options.try(:[], :address3),
+          suburb: options.try(:[], :suburb),
+          city: options.try(:[], :city),
+          state: options.try(:[], :state),
+          postcode: options.try(:[], :postcode),
+          country: options.try(:[], :country)
+        })
+      end
+
+      # Add Bank details to +post+ hash
+      #
+      # ==== Options
+      # * <tt>bank_name</tt> -- Bank Name (REQUIRED) (< 50 chars)
+      # * <tt>account_name</tt> -- Account Holder name (REQUIRED) (< 20 chars)
+      # * <tt>account_number</tt> -- valid account number form merchants country
+      #
+      def add_bank_details(post, options)
+        post[:bankDetails] = {
+          name: options[:bank_name],
+          branchAddress1: options[:bank_address1],
+          branchAddress2: options[:bank_address2],
+          account: {
+            name: options[:account_name],
+            number: options[:account_number]
+          }
+        }
+      end
+
+      # Add channel
+      #
+      # ==== Options
+      #
+      # * <tt>channel</tt> -- One of { web | vt | api | batch | recurring | ivr | mobile }
+      #
+      def add_channel(post, options)
+        post[:channel] = options[:channel] || 'web'
+      end
+
+      # Add initial payment
+      #
+      # ==== Options
+      #
+      # * <tt>initial_date</tt> -- Initial payment date
+      # * <tt>intital_amount</tt> -- Amount to bill
+      #
+      def add_initial_payment(post, options)
+        post[:initialPayment] = {
+          'date' => options[:initial_date] || options[:start_date] || Date.today.at_beginning_of_month.next_month,
+          'amount' => amount(options[:initial_amount]) || amount(options[:amount])
+        }
+      end
+
+      #
+      # instalmentFailOption
+      # "none | add-to-next | add-to-last | add-at-end"
+      #
+      def add_invoice(post, money, options)
+        add_amount(post, money)
+        post[:currency] = options[:currency] || currency(money)
+        if options.has_key?('total_amount')
+          post[:totalAmount] = options[:total_amount]
+          post[:instalmentFailOption] = options[:instalment_fail_option] || 'none'
+        end
+      end
+
+      def add_amount(post, money)
+        post[:amount] = amount(money)
+      end
+
+      # Add frequency
+      #
+      # ==== Options
+      #
+      # * <tt>frequency</tt>: one of { daily | weekly | fortnightly | 4-weekly | 8-weekly | 12-weekly |
+      # monthly | 2-monthly | 3-monthly | 6-monthly | 12-monthly }
+      #
+      def add_frequency(post, options)
+        post[:frequency] = options[:frequency]
+      end
+
+      def add_merchant(post, options)
+        post[:merchant]  = {
+          'id' => options[:merchant_id] || @merchant_id
+          # 'subAccount' => options[:sub_account_id] || @sub_account_id
+        }
+      end
+
+      # Add payment method
+      #
+      # ==== Options
+      #
+      # * <tt>payment_method_type</tt>: token | iframe | card
+      # * <tt>token</tt>: token | iframe | card
+      #
+      def add_payment_method(post, options, value)
+        if options[:payment_method_type] == 'iframe'
+          post[:paymentMethod] = {
+            type: options[:payment_method_type],
+            iframe: { 'value': value }
+          }
+
+        else
+          post[:paymentMethod] = {
+            type: options[:payment_method_type] || 'token',
+            token: { 'value': value }
+          }
+        end
+      end
+
+      def add_references(post, options)
+        post[:reference1] = options[:reference_1]
+        post[:reference2] = options[:reference_2]
+      end
+
+      def add_debit_card_references(post, options)
+        post[:statementReference1] = options[:statementReference1]
+        post[:statementReference2] = options[:statementReference2]
+        post[:merchantReference1] = options[:merchantReference1]
+        post[:merchantReference2] = options[:merchantReference2]
+        post[:merchantReference3] = options[:merchantReference3]
+      end
+
+      # For Recurring Plans Flo2Cash manages charging and retries on defined
+      # intervals
+      #
+      # For a tokenised card, merchant can upload a batch of payments with retry
+      # information in the batch file. Flo2Cash will retry at the specified
+      # intervals
+      #
+      # ==== Parameters
+      #
+      # * <tt>options</tt> -- A hash of Options
+      #
+      # ==== Options
+      #
+      # * <tt>retry_preference_perform</tt> -- true | false
+      # * <tt>retry_preference_frequency</tt> Number of days in between attempts
+      # * <tt>retry_preference_max_retry</tt> Number of attempts (max value 7)
+      #
+      # Based on the chosen parameters, retires are attempted every calendar day,
+      # irrespective of the weekend or a public holiday.
+      #
+      def add_retry_preferences(post, options)
+        post[:retryPreferences] = {
+          'perform' => options[:retry_preference_perform] || false,
+          'frequencyInDays' => options[:retry_preference_frequency] || 1,
+          'maxAttempts' => options[:retry_preference_max_retry] || 7
+        }
+      end
+
+      def add_type(post, type_option)
+        post[:type] = type_option
+      end
+
+      def add_unique_reference(post, options)
+        post[:uniqueReference] = options[:unique_reference]
+      end
+
+      # paymentMethod[type] options: iframe | card
+      #
+      def add_card_data(post, card)
+        post[:paymentMethod] = {
+          type: 'card', # iframe | card
+          card: {
+            number: card.number,
+            expiryDate: expdate(card),
+            nameOnCard: card.name
+          }
+        }
+      end
+
+      def add_geolocation(post, options)
+        post[:geolocation] = {
+          latitude: options[:latitude],
+          longitude: options[:longitude]
+        }
+      end
+
+      def authorization_from(action, response)
+        case action
+        when :store
+          response['token']
+        when :payment, :purchase
+          response['number']
+        else
+          response['id']
+        end
+      end
+
+      def post_data(verb, params)
+        return nil if verb == :get || params.nil?
+
+        params.to_json
+      end
+
+      def error_code_from(succeeded, response)
+        unless succeeded
+          response['messages'].try(:join, '; ').presence ||
+            parse_error(response['response']).presence ||
+            'Unable to read error message'
+        end
+      end
+
+      def parse_error(response={})
+        STANDARD_ERROR_CODE_MAPPING[response['providerResponse']].presence ||
+          response['message']
+      end
+
+      def expdate(card)
+        "#{format(card.month, :two_digits)}#{format(card.year, :two_digits)}"
+      end
+
+      def url(action, params)
+        arguments = ACTION_URL_MAP[action].scan(/.*%{(.*)}.*/).flatten.map(&:to_sym)
+
+        path = arguments.empty? ? ACTION_URL_MAP[action] : ACTION_URL_MAP[action] % params.slice(*arguments)
+
+        (test? ? test_url : live_url) + '/' + path
+      end
+    end
+  end
+end

--- a/lib/active_merchant/billing/gateways/flo2cash_rest.rb
+++ b/lib/active_merchant/billing/gateways/flo2cash_rest.rb
@@ -97,6 +97,7 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_type(post, 'purchase')
         add_channel(post, options)
+        add_particular(post, options)
         add_invoice(post, money, options)
         add_customer_resume(post, options)
         add_references(post, options)
@@ -482,6 +483,10 @@ module ActiveMerchant #:nodoc:
       def add_references(post, options)
         post[:reference1] = options[:reference_1]
         post[:reference2] = options[:reference_2]
+      end
+
+      def add_particular(post, options)
+        post[:particulars] = options[:particulars]
       end
 
       def add_debit_card_references(post, options)

--- a/lib/active_merchant/billing/gateways/flo2cash_rest.rb
+++ b/lib/active_merchant/billing/gateways/flo2cash_rest.rb
@@ -64,16 +64,16 @@ module ActiveMerchant #:nodoc:
       SUCCESS_STATUSES = %w(successful scheduled processing active cancelled pending-approval)
 
       ACTION_URL_MAP = {
-        store: 'cardTokens',
-        purchase: '/payments',
-        refund: "/payments/%{payment_id}/refunds",
-        create_card_plan: '/cardplans',
-        create_direct_debit_plan: "/directdebitplans",
-        update_card_plan: "/cardplans/%{plan_id}/status",
-        update_direct_debit_plan: "/directdebitplans/%{plan_id}/status",
-        retrieve_card_plan: "/cardplans/%{plan_id}",
-        retrieve_card_payment: "/payments/%{payment_id}",
-        retrieve_direct_debit_plan: "/directdebitplans/%{plan_id}",
+        store: 'cardtokens',
+        purchase: 'payments',
+        refund: "payments/%{payment_id}/refunds",
+        create_card_plan: 'cardplans',
+        create_direct_debit_plan: "directdebitplans",
+        update_card_plan: "cardplans/%{plan_id}/status",
+        update_direct_debit_plan: "directdebitplans/%{plan_id}/status",
+        retrieve_card_plan: "cardplans/%{plan_id}",
+        retrieve_card_payment: "payments/%{payment_id}",
+        retrieve_direct_debit_plan: "directdebitplans/%{plan_id}",
       }
 
       # Creates a new Flo2cachRest gateway
@@ -88,6 +88,9 @@ module ActiveMerchant #:nodoc:
       #
       def initialize(options = {})
         requires!(options, :merchant_id, :api_key)
+        @merchant_id = options[:merchant_id]
+        @api_key = options[:api_key]
+
         super
       end
 
@@ -109,7 +112,6 @@ module ActiveMerchant #:nodoc:
           else
             store(payment_method, options).authorization
           end
-
         add_payment_method(post, options, token)
 
         commit(:post, :purchase, post, options)
@@ -347,8 +349,6 @@ module ActiveMerchant #:nodoc:
           fax: options[:fax],
           email: options[:email]
         }
-
-        add_references(post, options)
       end
 
       def add_device_info(post, options)

--- a/lib/active_merchant/billing/gateways/flo2cash_rest.rb
+++ b/lib/active_merchant/billing/gateways/flo2cash_rest.rb
@@ -328,7 +328,11 @@ module ActiveMerchant #:nodoc:
       end
 
       def message_from(succeeded, response)
-        succeeded ? 'Succeeded' : error_code_from(false, response)
+        if succeeded
+          'Succeeded'
+        else
+          response.dig('response', 'message').presence || error_code_from(false, response)
+        end
       end
 
       def add_customer_resume(post, options)

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -352,6 +352,10 @@ flo2cash:
   password: ANOTHERCREDENTIAL
   account_id: ANOTHERCREDENTIAL
 
+flo2cash_rest:
+  api_key: APIKEY
+  merchant_id: MERCHANTID
+
 flo2cash_simple:
   username: SOMECREDENTIAL
   password: ANOTHERCREDENTIAL

--- a/test/remote/gateways/remote_flo2cash_rest_test.rb
+++ b/test/remote/gateways/remote_flo2cash_rest_test.rb
@@ -127,7 +127,8 @@ class RemoteFlo2cashRestTest < Test::Unit::TestCase
     response = @gateway.purchase(@card_declined_amount, @credit_card, @options)
     assert_failure response
 
-    assert_equal Gateway::STANDARD_ERROR_CODE[:card_declined], response.message
+    assert_equal Gateway::STANDARD_ERROR_CODE[:card_declined], response.error_code
+    assert_equal 'declined - insufficient funds', response.message
   end
 
   def test_successful_refund

--- a/test/remote/gateways/remote_flo2cash_rest_test.rb
+++ b/test/remote/gateways/remote_flo2cash_rest_test.rb
@@ -1,0 +1,211 @@
+require 'test_helper'
+
+class RemoteFlo2cashRestTest < Test::Unit::TestCase
+  def setup
+    @gateway = Flo2cashRestGateway.new(fixtures(:flo2cash_rest))
+
+    @amount = 1000
+    @card_declined_amount = 1751
+    @credit_card = credit_card('4000100011112224')
+
+    @auth_options = {
+      api_key: fixtures(:flo2cash_rest)[:api_key],
+      merchant_id: fixtures(:flo2cash_rest)[:merchant_id],
+    }
+
+    @payment_options = {
+      start_date: Date.today.next_month.to_s(:ymd),
+      initial_date: Date.today.next_month.to_s(:ymd),
+      amount: @amount,
+      currency: 'NZD',
+      email: 'john.doe@test.com',
+      first_name: 'John',
+      last_name: 'Doe',
+      title: 'Mr.',
+      address: address.merge({ state: 'VIC', country: 'NZ' }),
+      frequency: 'monthly'
+    }
+
+    @debit_options = @payment_options.merge({
+      start_date: Date.today.next_month.to_s(:ymd),
+      initial_date: Date.today.next_month.to_s(:ymd),
+      bank_name: 'BNZ',
+      bank_address1: '123 Street',
+      bank_address2: 'Suburb, City',
+      account_name: 'Account Name',
+      account_number: '4411000000000000'
+    })
+
+    @options = @auth_options.merge(@payment_options)
+  end
+
+  def test_success_store
+    response = @gateway.store(@credit_card, @auth_options)
+    assert_success response
+  end
+
+  def test_fail_store
+    invalid_card = credit_card('1')
+    response = @gateway.store(invalid_card, @auth_options)
+    assert_failure response
+    assert_equal 'Card number is not valid', response.message
+  end
+
+  def test_success_create_card_plan
+    store = @gateway.store(@credit_card, @auth_options)
+    assert_success store
+
+    response = @gateway.create_card_plan(store.authorization, @options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
+  def test_fail_create_card_plan
+    store = @gateway.store(@credit_card, @auth_options)
+    assert_success store
+
+    fail_options = @options.except(:frequency)
+    response = @gateway.create_card_plan(store.authorization, fail_options)
+    assert_failure response
+    assert_equal 'Frequency can not be empty', response.message
+  end
+
+  def test_success_update_card_plan
+    # Tokenize
+    store = @gateway.store(@credit_card, @auth_options)
+    assert_success store
+
+    # Create an active Card Plan
+    card_plan = @gateway.create_card_plan(store.authorization, @options)
+    assert_success card_plan
+    assert_equal 'Succeeded', card_plan.message
+
+    # Change the Card Plan Status
+    response = @gateway.update_card_plan(card_plan.authorization, 'cancelled', @options)
+    assert_success response
+
+    assert_equal 'cancelled', response.params['status']
+  end
+
+  def test_success_retrieve_card_plan
+    # Tokenize
+    store = @gateway.store(@credit_card, @auth_options)
+    assert_success store
+
+    # Create an active Card Plan
+    card_plan = @gateway.create_card_plan(store.authorization, @options)
+    assert_success card_plan
+    assert_equal 'Succeeded', card_plan.message
+
+    # Retrieve Card Plan
+    response = @gateway.retrieve_card_plan(card_plan.authorization, @options)
+    assert_success response
+  end
+
+  def test_fail_retrieve_card_plan
+    response = @gateway.retrieve_card_plan('1', @options)
+    assert_failure response
+
+    assert_equal 'Card Plan not found', response.message
+  end
+
+  def test_successful_purchase_with_credit_card
+    options = @options.merge(@auth_options)
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+  end
+
+  def test_successful_purchase_with_token
+    store = @gateway.store(@credit_card, @auth_options)
+    assert_success store
+
+    response = @gateway.purchase(@amount, store.authorization, @options)
+    assert_success response
+  end
+
+  def test_fail_purchase
+    response = @gateway.purchase(@card_declined_amount, @credit_card, @options)
+    assert_failure response
+
+    assert_equal Gateway::STANDARD_ERROR_CODE[:card_declined], response.message
+  end
+
+  def test_successful_refund
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    refund = @gateway.refund(@amount, purchase.authorization, @options)
+    assert_success refund
+    assert_equal 'Succeeded', refund.message
+  end
+
+  def test_partial_refund
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    assert refund = @gateway.refund(@amount-1, purchase.authorization, @options)
+    assert_success refund
+  end
+
+  def test_fail_refund
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    refund = @gateway.refund(@amount * 2, purchase.authorization, @options)
+    assert_failure refund
+    assert_equal 'This Refund would exceed the amount of the original transact', refund.message
+  end
+
+  def test_success_card_payment
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    response = @gateway.retrieve_card_payment(purchase.authorization, @options)
+    assert_success response
+  end
+
+  def test_fail_card_payment
+    response = @gateway.retrieve_card_payment('1', @options)
+    assert_failure response
+    assert_equal 'Payment not found', response.message
+  end
+
+  def test_success_create_direct_debit_plan
+    options = @debit_options.merge(@auth_options)
+    response = @gateway.create_direct_debit_plan(options)
+    assert_success response
+  end
+
+  def test_fail_create_direct_debit_plan
+    options = @debit_options.merge(@auth_options).except(:account_number)
+    response = @gateway.create_direct_debit_plan(options)
+    assert_failure response
+    assert_equal "'Bank Details. Account. Number' must not be empty.", response.message
+  end
+
+  def test_success_retrieve_direct_debit_plan
+    options = @debit_options.merge(@auth_options)
+    direct_debit = @gateway.create_direct_debit_plan(options)
+    assert_success direct_debit
+
+    response = @gateway.retrieve_direct_debit_plan(direct_debit.authorization, @auth_options)
+    assert_success response
+  end
+
+  def test_fail_retrieve_direct_debit_plan
+    response = @gateway.retrieve_direct_debit_plan('1', @auth_options)
+    assert_failure response
+    assert_equal 'Direct Debit Plan not found', response.message
+  end
+
+  def test_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card.number, transcript)
+    assert_scrubbed(@gateway.options[:merchant_id], transcript)
+    assert_scrubbed(@gateway.options[:api_key], transcript)
+  end
+end

--- a/test/unit/gateways/flo2cash_rest_test.rb
+++ b/test/unit/gateways/flo2cash_rest_test.rb
@@ -1,0 +1,503 @@
+require 'test_helper'
+
+class Flo2cashRestTest < Test::Unit::TestCase
+  include CommStub
+
+  def setup
+    Base.mode = :test
+
+    @gateway = Flo2cashRestGateway.new(
+      :merchant_id => 'account_id',
+      :api_key => 'api_key'
+    )
+
+    @credit_card = credit_card
+    @token = '105463784931'
+    @amount = 100
+
+    @options = {
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase',
+      api_key: 'xxx',
+      merchant_id: 'mid',
+    }
+  end
+
+  def test_successful_purchase
+    @gateway.expects(:ssl_request).returns(successful_purchase_response)
+
+    response = @gateway.purchase(@amount, @token, @options)
+    assert_success response
+
+    assert_equal 'P1904M0000251709', response.authorization
+    assert response.test?
+  end
+
+  def test_fail_purchase
+    @gateway.expects(:ssl_request).returns(fail_purchase_response)
+
+    response = @gateway.purchase(@amount, @token, @options)
+    assert_failure response
+    assert_equal Gateway::STANDARD_ERROR_CODE[:card_declined], response.error_code
+  end
+
+  def test_successful_refund
+    @gateway.expects(:ssl_request).returns(successful_refund_response)
+
+    response = @gateway.refund(@amount, 'payment_id', @options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
+  def test_failed_refund
+    @gateway.expects(:commit).returns(failed_refund_response)
+
+    response = @gateway.refund(@amount, 'payment_id', @options)
+    assert_failure response
+    assert_equal 'This Refund would exceed the amount of the original transact', response.message
+  end
+
+  def test_sucessful_card_plan_creation
+    @gateway.expects(:ssl_request).returns(successful_card_plan_creation_response)
+
+    response = @gateway.create_card_plan('token', @options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+    assert_equal 25, response.params['paymentSchedule'].count
+  end
+
+  def test_fail_retrieve_card_plan
+    @gateway.expects(:commit).returns(fail_retrieve_card_plan_response)
+
+    response = @gateway.retrieve_card_plan('x', @options)
+    assert_equal 'Card Plan not found', response.message
+  end
+
+  private
+
+  def successful_store_response
+    {
+      'token' => '105463784931',
+      'created' => '2019-03-30T15:11:45',
+      'uniqueReference' => 'uuid',
+      'merchant' => { 'id' => 51145 },
+      'card' =>{
+        'type' => 'visa',
+        'mask' => '400010******2224',
+        'bin' => '400010',
+        'expiryDate' => '0920',
+        'lastFour' => '2224',
+        'nameOnCard' => 'Longbob Longsen'} }
+  end
+
+  def successful_purchase_response
+    {
+      "number"=>"P1904M0000251709",
+      "timestamp"=>"2019-04-08T11:36:57",
+      "type"=>"purchase",
+      "status"=>"successful",
+      "channel"=>"web",
+      "reference"=>nil,
+      "particulars"=>nil,
+      "amount"=>10.0,
+      "amountCaptured"=>10.0,
+      "amountRefunded"=>0.0,
+      "currency"=>"NZD",
+      "initiatedBy"=>nil,
+      "receiptRecipient"=>"john.doe@test.com",
+      "response"=>{
+        "code"=>0,
+        "message"=>"successful",
+        "providerResponse"=>"00",
+        "authCode"=>"C52AA4"
+      },
+      "merchant"=>{
+        "id"=>51145,
+        "subAccount"=>11178
+      },
+      "paymentMethod"=>{
+        "card"=>{
+          "type"=>"visa",
+          "mask"=>"400010******2224",
+          "bin"=>"400010",
+          "lastFour"=>"2224",
+          "expiryDate"=>"0920",
+          "nameOnCard"=>"Longbob Longsen",
+          "token"=>"37365923419"
+        }
+      }
+    }.to_json
+  end
+
+  def fail_purchase_response
+    {
+      "number"=>"P1904M0000251720",
+      "timestamp"=>"2019-04-08T11:57:11",
+      "type"=>"purchase",
+      "status"=>"declined",
+      "channel"=>"web",
+      "reference"=>nil,
+      "particulars"=>nil,
+      "amount"=>17.51,
+      "amountCaptured"=>0.0,
+      "amountRefunded"=>0.0,
+      "currency"=>"NZD",
+      "initiatedBy"=>nil,
+      "receiptRecipient"=>"john.doe@test.com",
+      "response"=>{
+        "code"=>200,
+        "message"=>"declined - insufficient funds",
+        "providerResponse"=>"51",
+        "authCode"=>"CE1D11"
+      },
+      "merchant"=>{
+        "id"=>51145,
+        "subAccount"=>11178
+      },
+      "paymentMethod"=>{
+        "card"=>{
+          "type"=>"visa",
+          "mask"=>"400010******2224",
+          "bin"=>"400010",
+          "lastFour"=>"2224",
+          "expiryDate"=>"0920",
+          "nameOnCard"=>"Longbob Longsen",
+          "token"=>"93765945121"
+        }
+      },
+      "device"=>nil,
+      "geolocation"=>nil,
+      "refunds"=>nil,
+      "captures"=>nil
+    }.to_json
+  end
+
+  def successful_refund_response
+    {
+      "number" => "P1904M0000251755",
+      "timestamp" => "2019-04-08T12:51:52",
+      "type" => "purchase",
+      "status" => "successful",
+      "channel" => "web",
+      "reference" => nil,
+      "particulars" => nil,
+      "amount" => 10.0,
+      "amountCaptured" => 10.0,
+      "amountRefunded" => 10.0,
+      "currency" => "NZD",
+      "initiatedBy" => nil,
+      "receiptRecipient" => "john.doe@test.com",
+      "response" => {
+        "code" => 0,
+        "message" => "successful",
+        "providerResponse" => "00",
+        "authCode" => "EA0D5D"
+      },
+      "merchant" => {
+        "id" => 51145,
+        "subAccount" => 11178
+      },
+      "paymentMethod" => {
+        "card" => {
+          "type" => "visa",
+          "mask" => "400010******2224",
+          "bin" => "400010",
+          "lastFour" => "2224",
+          "expiryDate" => "0920",
+          "nameOnCard" => "Longbob Longsen",
+          "token" => "109065965928"
+        }
+      },
+      "device" => nil,
+      "geolocation" => nil,
+      "refunds" => [
+        {
+          "number" => "P1904M0000251756",
+          "timestamp" => "2019-04-08T00:51:54",
+          "amount" => 10.0,
+          "currency" => "NZD",
+          "reference" => nil,
+          "particulars" => nil,
+          "response" => {
+            "code" => 0,
+            "message" => "Successful",
+            "providerResponse" => "00",
+            "authCode" => "6A6A8D"
+          }
+        }
+      ],
+      "captures" => nil
+    }.to_json
+  end
+
+  def failed_refund_response
+    ActiveMerchant::Billing::Response.new(
+      false,
+      'This Refund would exceed the amount of the original transact')
+  end
+
+  def successful_card_plan_creation_response
+    {
+      "id" => 2618,
+      "created" => "2019-04-08T15:41:15",
+      "startDate" => "2019-05-08",
+      "amendmentDate" => nil,
+      "nextPaymentDate" => "2019-05-08",
+      "type" => "recurring",
+      "frequency" => "monthly",
+      "status" => "active",
+      "statusChangedDate" => "2019-04-08T15:41:15",
+      "amount" => 10.0,
+      "totalAmount" => nil,
+      "currency" => "NZD",
+      "reference" => "",
+      "particulars" => "",
+      "instalmentFailOption" => "",
+      "retryPreferences" => nil,
+      "merchant" => {
+        "id" => 51145,
+        "subAccount" => 11178
+      },
+      "initialPayment" => {
+        "date" => "2019-05-08",
+        "amount" => 10.0
+      },
+      "payer" => {
+        "companyName" => nil,
+        "title" => "Mr.",
+        "firstNames" => "John",
+        "lastName" => "Doe",
+        "dateOfBirth" => nil,
+        "telephoneHome" => nil,
+        "telephoneWork" => nil,
+        "telephoneMobile" => nil,
+        "fax" => nil,
+        "email" => "john.doe@test.com",
+        "address1" => nil,
+        "address2" => nil,
+        "address3" => nil,
+        "suburb" => nil,
+        "city" => nil,
+        "postcode" => nil,
+        "state" => "",
+        "country" => ""
+      },
+      "card" => {
+        "type" => "Visa",
+        "mask" => "400010******2224",
+        "bin" => "400010",
+        "lastFour" => "2224",
+        "expiryDate" => "0920",
+        "nameOnCard" => "Longbob Longsen"
+      },
+      "amendments" => [],
+      "paymentSchedule" => [
+        {
+          "date" => "2019-05-08",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "payment" => nil,
+          "retries" => nil
+        },
+        {
+          "date" => "2019-05-08",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "payment" => nil,
+          "retries" => nil
+        },
+        {
+          "date" => "2019-06-08",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "payment" => nil,
+          "retries" => nil
+        },
+        {
+          "date" => "2019-07-08",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "payment" => nil,
+          "retries" => nil
+        },
+        {
+          "date" => "2019-08-08",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "payment" => nil,
+          "retries" => nil
+        },
+        {
+          "date" => "2019-09-08",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "payment" => nil,
+          "retries" => nil
+        },
+        {
+          "date" => "2019-10-08",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "payment" => nil,
+          "retries" => nil
+        },
+        {
+          "date" => "2019-11-08",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "payment" => nil,
+          "retries" => nil
+        },
+        {
+          "date" => "2019-12-08",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "payment" => nil,
+          "retries" => nil
+        },
+        {
+          "date" => "2020-01-08",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "payment" => nil,
+          "retries" => nil
+        },
+        {
+          "date" => "2020-02-08",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "payment" => nil,
+          "retries" => nil
+        },
+        {
+          "date" => "2020-03-08",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "payment" => nil,
+          "retries" => nil
+        },
+        {
+          "date" => "2020-04-08",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "payment" => nil,
+          "retries" => nil
+        },
+        {
+          "date" => "2020-05-08",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "payment" => nil,
+          "retries" => nil
+        },
+        {
+          "date" => "2020-06-08",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "payment" => nil,
+          "retries" => nil
+        },
+        {
+          "date" => "2020-07-08",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "payment" => nil,
+          "retries" => nil
+        },
+        {
+          "date" => "2020-08-08",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "payment" => nil,
+          "retries" => nil
+        },
+        {
+          "date" => "2020-09-08",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "payment" => nil,
+          "retries" => nil
+        },
+        {
+          "date" => "2020-10-08",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "payment" => nil,
+          "retries" => nil
+        },
+        {
+          "date" => "2020-11-08",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "payment" => nil,
+          "retries" => nil
+        },
+        {
+          "date" => "2020-12-08",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "payment" => nil,
+          "retries" => nil
+        },
+        {
+          "date" => "2021-01-08",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "payment" => nil,
+          "retries" => nil
+        },
+        {
+          "date" => "2021-02-08",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "payment" => nil,
+          "retries" => nil
+        },
+        {
+          "date" => "2021-03-08",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "payment" => nil,
+          "retries" => nil
+        },
+        {
+          "date" => "2021-04-08",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "payment" => nil,
+          "retries" => nil
+        }
+      ]
+    }.to_json
+  end
+
+  def fail_retrieve_card_plan_response
+    ActiveMerchant::Billing::Response.new(false, 'Card Plan not found')
+  end
+end

--- a/test/unit/gateways/flo2cash_rest_test.rb
+++ b/test/unit/gateways/flo2cash_rest_test.rb
@@ -74,6 +74,22 @@ class Flo2cashRestTest < Test::Unit::TestCase
     assert_equal 'Card Plan not found', response.message
   end
 
+  def test_successful_direct_debit_plan_creation
+    @gateway.expects(:ssl_request).returns(successful_direct_debit_plan_response)
+
+    response = @gateway.create_direct_debit_plan(@options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+    assert_equal 25, response.params['paymentSchedule'].count
+  end
+
+  def test_fail_direct_debit_plan_creation
+    @gateway.expects(:commit).returns(fail_direct_debit_plan_response)
+
+    response = @gateway.create_direct_debit_plan(@options)
+    assert_equal "'Bank Details. Account. Number' must not be empty.", response.message
+  end
+
   private
 
   def successful_store_response
@@ -499,5 +515,247 @@ class Flo2cashRestTest < Test::Unit::TestCase
 
   def fail_retrieve_card_plan_response
     ActiveMerchant::Billing::Response.new(false, 'Card Plan not found')
+  end
+
+  def successful_direct_debit_plan_response
+    {
+      "id" => 4559,
+      "created" => "2019-04-09T15:18:12",
+      "startDate" => "2019-05-09",
+      "approvalDate" => nil,
+      "amendmentDate" => nil,
+      "nextPaymentDate" => "2019-05-09",
+      "type" => "recurring",
+      "frequency" => "monthly",
+      "status" => "pending-approval",
+      "statusChangedDate" => "2019-04-09T15:18:12",
+      "amount" => 10.0,
+      "totalAmount" => nil,
+      "currency" => "NZD",
+      "reference" => "",
+      "particulars" => "",
+      "instalmentFailOption" => "",
+      "merchantReference1" => nil,
+      "merchantReference2" => nil,
+      "merchantReference3" => nil,
+      "merchant" => {
+        "id" => 51145
+      },
+      "initialPayment" => {
+        "date" => "2019-05-09",
+        "amount" => 10.0
+      },
+      "payer" => {
+        "companyName" => nil,
+        "title" => "Mr.",
+        "firstNames" => "John",
+        "lastName" => "Doe",
+        "dateOfBirth" => nil,
+        "telephoneHome" => nil,
+        "telephoneWork" => nil,
+        "telephoneMobile" => nil,
+        "fax" => nil,
+        "email" => "john.doe@test.com",
+        "address1" => nil,
+        "address2" => nil,
+        "address3" => nil,
+        "suburb" => nil,
+        "city" => nil,
+        "postcode" => nil,
+        "state" => "",
+        "country" => ""
+      },
+      "bankDetails" => {
+        "name" => "BNZ",
+        "branchAddress1" => "123 Street",
+        "branchAddress2" => "Suburb, City",
+        "account" => {
+          "name" => "Account Name",
+          "number" => "44 - 1100 - 0000000 - 000"
+        }
+      },
+      "amendments" => [],
+      "paymentSchedule" => [
+        {
+          "date" => "2019-05-09",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "directDebit" => nil
+        },
+        {
+          "date" => "2019-05-09",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "directDebit" => nil
+        },
+        {
+          "date" => "2019-06-09",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "directDebit" => nil
+        },
+        {
+          "date" => "2019-07-09",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "directDebit" => nil
+        },
+        {
+          "date" => "2019-08-09",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "directDebit" => nil
+        },
+        {
+          "date" => "2019-09-09",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "directDebit" => nil
+        },
+        {
+          "date" => "2019-10-09",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "directDebit" => nil
+        },
+        {
+          "date" => "2019-11-09",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "directDebit" => nil
+        },
+        {
+          "date" => "2019-12-09",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "directDebit" => nil
+        },
+        {
+          "date" => "2020-01-09",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "directDebit" => nil
+        },
+        {
+          "date" => "2020-02-09",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "directDebit" => nil
+        },
+        {
+          "date" => "2020-03-09",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "directDebit" => nil
+        },
+        {
+          "date" => "2020-04-09",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "directDebit" => nil
+        },
+        {
+          "date" => "2020-05-09",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "directDebit" => nil
+        },
+        {
+          "date" => "2020-06-09",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "directDebit" => nil
+        },
+        {
+          "date" => "2020-07-09",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "directDebit" => nil
+        },
+        {
+          "date" => "2020-08-09",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "directDebit" => nil
+        },
+        {
+          "date" => "2020-09-09",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "directDebit" => nil
+        },
+        {
+          "date" => "2020-10-09",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "directDebit" => nil
+        },
+        {
+          "date" => "2020-11-09",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "directDebit" => nil
+        },
+        {
+          "date" => "2020-12-09",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "directDebit" => nil
+        },
+        {
+          "date" => "2021-01-09",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "directDebit" => nil
+        },
+        {
+          "date" => "2021-02-09",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "directDebit" => nil
+        },
+        {
+          "date" => "2021-03-09",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "directDebit" => nil
+        },
+        {
+          "date" => "2021-04-09",
+          "status" => "scheduled",
+          "amount" => 10.0,
+          "skip" => false,
+          "directDebit" => nil
+        }
+      ]
+    }.to_json
+  end
+
+  def fail_direct_debit_plan_response
+    ActiveMerchant::Billing::Response.new(false, "'Bank Details. Account. Number' must not be empty.")
   end
 end


### PR DESCRIPTION
Here there is a new Gateway creation flo2cash REST.

This is the schema of methods used to interact with flo2cash REST endpoints

   * Card Payment
      + purchase
      + refunds
      + retrieve_card_payment
 * Card Plan
      + create_card_plan
      + update_card_plan (only change status)
      + retrieve_card_plan
* Direct Debit Plan
     + create_direct_debit_plan
     + update_direct_debit_plan (only change status)
     + retrieve_direct_debit_plan
* card tokenization
     + store
