### PR TITLE
Update live url

### DIFF
--- a/lib/active_merchant/billing/gateways/flo2cash_rest.rb
+++ b/lib/active_merchant/billing/gateways/flo2cash_rest.rb
@@ -17,7 +17,7 @@ module ActiveMerchant #:nodoc:
     #
     class Flo2cashRestGateway < Gateway
       self.test_url = 'https://sandbox.flo2cash.com/api'
-      self.live_url = 'https://secure.flo2cash.co.nz/web2pay'
+      self.live_url = 'https://secure.flo2cash.co.nz/api'
 
       self.supported_countries = ['NZ']
       self.default_currency = 'NZD'


### PR DESCRIPTION
The `live_url` had the path set incorrectly to `/web2pay` when it should have been `/api`

Refs #166401969 (internal ticket)

```Shell
➜  waysact-activemerchant git:(166401969-fix-live-url-flo2cash-rest) ✗ bundle exec ruby -Itest test/remote/gateways/remote_flo2cash_rest_test.rb
Loaded suite test/remote/gateways/remote_flo2cash_rest_test
Started
....................

Finished in 11.395321 seconds.
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
20 tests, 49 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1.76 tests/s, 4.30 assertions/s
➜  waysact-activemerchant git:(166401969-fix-live-url-flo2cash-rest) ✗ bundle exec ruby -Itest test/unit/gateways/flo2cash_rest_test.rb
Loaded suite test/unit/gateways/flo2cash_rest_test
Started
........

Finished in 0.006991 seconds.
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
8 tests, 33 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1144.33 tests/s, 4720.35 assertions/s
```