### PR TITLE
Send canvasser_name to Jackson River

### DIFF
--- a/lib/active_merchant/billing/gateways/jackson_river.rb
+++ b/lib/active_merchant/billing/gateways/jackson_river.rb
@@ -74,6 +74,7 @@ module ActiveMerchant #:nodoc:
       def add_metadata(post, options = {})
         post[:ms] = options[:market_source] if options[:market_source]
         post[:guid] = options[:guid] if options[:guid]
+        post[:canvasser_name] = truncate(options[:canvasser_name], 100) if options[:canvasser_name]
       end
 
       def parse(body)

--- a/test/remote/gateways/remote_jackson_river_test.rb
+++ b/test/remote/gateways/remote_jackson_river_test.rb
@@ -12,7 +12,8 @@ class RemoteJacksonRiverTest < Test::Unit::TestCase
       billing_address: address,
       description: 'Store Purchase',
       form_id: 34467,
-      market_source: 'FooBar_MarketSource'
+      market_source: 'FooBar_MarketSource',
+      canvasser_name: 'John Doe Canvasser'
     }
   end
 


### PR DESCRIPTION
I am adding that in the `add_metadata` field and ensure we don’t send more than 100 characters.

I cannot use the remote test because the customer's test credentials don't work anymore, but the unit tests pass.

```Shell
$  ruby -Itest test/unit/gateways/jackson_river_test.rb
Loaded suite test/unit/gateways/jackson_river_test
Started
...

Finished in 0.004972 seconds.
------------------------------------------------------------------------------------------------------------------------------------------------------------
3 tests, 9 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
------------------------------------------------------------------------------------------------------------------------------------------------------------
603.38 tests/s, 1810.14 assertions/s
```