### PR TITLE
Add option to skip the initial payment block

### DIFF
--- a/lib/active_merchant/billing/gateways/flo2cash_rest.rb
+++ b/lib/active_merchant/billing/gateways/flo2cash_rest.rb
@@ -178,7 +178,7 @@ module ActiveMerchant #:nodoc:
         add_invoice(post, options[:amount], options)
         add_references(post, options)
         add_merchant(post, options)
-        add_initial_payment(post, options)
+        add_initial_payment(post, options) unless options[:skip_initial_payment]
         add_retry_preferences(post, options)
 
         commit(:post, :create_card_plan, post, options)
@@ -221,7 +221,7 @@ module ActiveMerchant #:nodoc:
         add_invoice(post, options[:amount], options)
         add_debit_card_references(post, options)
         add_merchant(post, options)
-        add_initial_payment(post, options)
+        add_initial_payment(post, options) unless options[:skip_initial_payment]
         add_retry_preferences(post, options)
         add_customer_data(post, options)
         add_address(post, options[:address])

--- a/test/remote/gateways/remote_flo2cash_rest_test.rb
+++ b/test/remote/gateways/remote_flo2cash_rest_test.rb
@@ -26,6 +26,10 @@ class RemoteFlo2cashRestTest < Test::Unit::TestCase
       frequency: 'monthly'
     }
 
+    skip_initial_payment = {
+      skip_initial_payment: 'yes'
+    }
+
     @debit_options = @payment_options.merge({
       start_date: Date.today.next_month.to_s(:ymd),
       initial_date: Date.today.next_month.to_s(:ymd),
@@ -37,6 +41,7 @@ class RemoteFlo2cashRestTest < Test::Unit::TestCase
     })
 
     @options = @auth_options.merge(@payment_options)
+    @options_skip_initial_payment = @options.merge(skip_initial_payment)
   end
 
   def test_success_store
@@ -56,6 +61,15 @@ class RemoteFlo2cashRestTest < Test::Unit::TestCase
     assert_success store
 
     response = @gateway.create_card_plan(store.authorization, @options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
+  def test_success_create_card_plan_without_initial_payment
+    store = @gateway.store(@credit_card, @auth_options)
+    assert_success store
+
+    response = @gateway.create_card_plan(store.authorization, @options_skip_initial_payment)
     assert_success response
     assert_equal 'Succeeded', response.message
   end


### PR DESCRIPTION
If `options[:skip_initial_payment]` is present, then we don’t send the `initial_payment` block in the recurring credit and debit.

[#166656936]