### PR TITLE
Use `merge!` instead of `merge`

### DIFF
--- a/lib/active_merchant/billing/gateways/flo2cash_rest.rb
+++ b/lib/active_merchant/billing/gateways/flo2cash_rest.rb
@@ -367,7 +367,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_address(post, options)
-        post[:payer].merge({
+        post[:payer].merge!({
           address1: options.try(:[], :address1),
           address2: options.try(:[], :address2),
           address3: options.try(:[], :address3),


### PR DESCRIPTION
The `!` method is necessary here otherwise the address is not added to the `post[:payer] hash.

[#166691460]