### PR TITLE
Add custom card brand mapping to SecureTrading

### DIFF
--- a/lib/active_merchant/billing/gateways/secure_trading.rb
+++ b/lib/active_merchant/billing/gateways/secure_trading.rb
@@ -23,7 +23,16 @@ module ActiveMerchant #:nodoc:
         '31004' => STANDARD_ERROR_CODE[:expired_card],
         '31009' => STANDARD_ERROR_CODE[:processing_error],
         '70000' => STANDARD_ERROR_CODE[:card_declined],
-      }
+      }.freeze
+
+      CARD_BRAND_MAP = {
+        'visa'              => 'VISA',
+        'master'            => 'MASTERCARD',
+        'maestro'           => 'MAESTRO',
+        'discover'          => 'DISCOVER',
+        'jcb'               => 'JCB',
+        'american_express'  => 'AMEX',
+      }.freeze
 
       def initialize(options={})
         requires!(options, :api_key, :user_id, :site_id)
@@ -142,7 +151,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def card_brand(card)
-        super.upcase
+        CARD_BRAND_MAP[super.downcase].presence || super.upcase
       end
 
       def exp_date(credit_card)

--- a/lib/active_merchant/billing/gateways/secure_trading.rb
+++ b/lib/active_merchant/billing/gateways/secure_trading.rb
@@ -151,7 +151,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def card_brand(card)
-        CARD_BRAND_MAP[super.downcase].presence || super.upcase
+        CARD_BRAND_MAP.fetch(super.downcase, super.upcase)
       end
 
       def exp_date(credit_card)

--- a/lib/active_merchant/billing/gateways/secure_trading.rb
+++ b/lib/active_merchant/billing/gateways/secure_trading.rb
@@ -26,11 +26,7 @@ module ActiveMerchant #:nodoc:
       }.freeze
 
       CARD_BRAND_MAP = {
-        'visa'              => 'VISA',
         'master'            => 'MASTERCARD',
-        'maestro'           => 'MAESTRO',
-        'discover'          => 'DISCOVER',
-        'jcb'               => 'JCB',
         'american_express'  => 'AMEX',
       }.freeze
 


### PR DESCRIPTION
we are getting the following error `"30000 Invalid field paymenttypedescription"`

inspecting the payload we noticed that we are sending the following payment type

```
 . . . <payment type="MASTER"> . . .
```

So here is a proposal to change the payment type as SecureTrading shows in their page https://www.securetrading.com/test-card-numbers/

Notice: We still use the algorithm of ActiveMerchant to discover the card type, but before use the returned value we map it to custom values.

Ref: [:ticket: #167430812](https://www.pivotaltracker.com/story/show/167430812)