### PR TITLE
Add title and make source configurable in Rapidata

### DIFF
--- a/lib/active_merchant/billing/gateways/rapidata.rb
+++ b/lib/active_merchant/billing/gateways/rapidata.rb
@@ -58,11 +58,13 @@ module ActiveMerchant #:nodoc:
       #
       # === Options
       #
+      # * <tt>title</tt>: the title of the donor
       # * <tt>first_name</tt>: first name of the donor
       # * <tt>last_name</tt>: last name of the donor
       # * <tt>email</tt>: the email of the donor
       #
       def add_customer_data(post, options)
+        post['Title'] = options[:title] if options[:title]
         post['FirstName'] = options[:first_name]
         post['LastName'] = options[:last_name]
         post['Email'] = options[:email] if options[:email]

--- a/lib/active_merchant/billing/gateways/rapidata.rb
+++ b/lib/active_merchant/billing/gateways/rapidata.rb
@@ -76,12 +76,12 @@ module ActiveMerchant #:nodoc:
       #
       # * <tt>database_id</tt>: an identifier supplied by Rapidata that identifies
       #   the database to which this record should be associated
-      # * <tt>source</tt>: a string, we're harcoding it for the time being.
+      # * <tt>source</tt>: string, limited to 50 chars
       # * <tt>other1...other20</tt>: twenty optional parameters that can be set and sent
       #
       def add_metadata(post, options)
         post['DatabaseId'] = options[:database_id]
-        post['Source'] = 'Evergiving'
+        post['Source'] = truncate(options[:source], 50)
         (1..20).each do |index|
           k = "other#{index}".to_sym
           post["Other#{index}"] = options[k] if options.key?(k)

--- a/test/remote/gateways/remote_rapidata_test.rb
+++ b/test/remote/gateways/remote_rapidata_test.rb
@@ -13,7 +13,8 @@ class RemoteRapidataTest < Test::Unit::TestCase
       frequency_id: 1,
       first_name: 'Bob',
       last_name: 'Longsen',
-      first_collection_date: (Date.current + 1.month).change(day: 1)
+      first_collection_date: (Date.current + 1.month).change(day: 1),
+      source: 'Evergiving'
     }
     @more_options = @options.merge(
       is_fulfilment: false,


### PR DESCRIPTION
I forgot this optional field (the supporter title). Also figured that we might want to pass the source as a configurable parameter, as our customers might chose a different representation of what it means for them.

Refs waysact/evergiving#3793

```
$ bundle exec ruby -Itest test/remote/gateways/remote_rapidata_test.rb
Loaded suite test/remote/gateways/remote_rapidata_test
Started
.....

Finished in 11.951801 seconds.
------------------------------------------------------------------------------------------------------------------------------------------------------------
5 tests, 12 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
------------------------------------------------------------------------------------------------------------------------------------------------------------
0.42 tests/s, 1.00 assertions/s
$ bundle exec ruby -Itest test/unit/gateways/rapidata_test.rb
Loaded suite test/unit/gateways/rapidata_test
Started
...

Finished in 0.003479 seconds.
------------------------------------------------------------------------------------------------------------------------------------------------------------
3 tests, 12 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
------------------------------------------------------------------------------------------------------------------------------------------------------------
862.32 tests/s, 3449.27 assertions/s
```