### PR TITLE
Allow purchase with store token in SecureTrading gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/secure_trading.rb
+++ b/lib/active_merchant/billing/gateways/secure_trading.rb
@@ -58,6 +58,7 @@ module ActiveMerchant #:nodoc:
 
         commit('authonly', post)
       end
+      alias_method :store, :authorize
 
       def purchase(money, payment_method, options={})
         post = build_xml_request('AUTH') do |xml|
@@ -134,7 +135,7 @@ module ActiveMerchant #:nodoc:
 
       def add_merchant(xml, options = {})
         xml.merchant do
-          xml.orderreference options[:unique_identifier]
+          xml.orderreference options[:unique_identifier] || options[:order_id]
         end
       end
 
@@ -168,11 +169,23 @@ module ActiveMerchant #:nodoc:
           #
           xml.accounttypedescription account_type(action)
 
-          xml.credentialsonfile '1'
-          
+          xml.credentialsonfile get_credential_on_file_number(action, options)
+
           if options[:parent_transaction_reference].present?
             xml.parenttransactionreference options[:parent_transaction_reference]
           end
+        end
+      end
+
+
+      # '1' identify that credentials are going to be stored for later
+      # '2' Customer Initiated Transaction (CIT) from previously-stored credentials
+      #
+      def get_credential_on_file_number(action, options)
+        if action == 'purchase' && options[:parent_transaction_reference].present?
+          '2'
+        else
+          '1'
         end
       end
 

--- a/test/remote/gateways/remote_secure_trading_test.rb
+++ b/test/remote/gateways/remote_secure_trading_test.rb
@@ -33,6 +33,46 @@ class RemoteSecureTradingTest < Test::Unit::TestCase
     assert_equal 'AUTH', auth.message
   end
 
+  def test_successful_purchase_with_authorization_token
+    auth = @gateway.authorize(1, @credit_card, @options)
+    auth_with_token = @gateway.purchase(@amount, nil, @options.merge({
+      parent_transaction_reference: auth.authorization
+    }))
+
+    assert_success auth_with_token
+    assert_equal 'AUTH', auth_with_token.message
+  end
+
+  def test_failED_purchase_with_authorization_token
+    auth = @gateway.authorize(1, @credit_card, @options)
+    auth_with_token = @gateway.purchase(@amount, nil, @options.merge({
+      parent_transaction_reference: 'whatever'
+    }))
+
+    assert_failure auth_with_token
+    assert_equal 'ERROR', auth_with_token.message
+  end
+
+  def test_successful_purchase_with_a_repeat_payment
+    auth = @gateway.purchase(@amount, @credit_card, @options)
+    auth_with_token_from_previous_purchase = @gateway.purchase(
+      @amount,
+      nil,
+      @options.merge({ parent_transaction_reference: auth.authorization }))
+
+    assert_success auth_with_token_from_previous_purchase
+    assert_equal 'AUTH', auth_with_token_from_previous_purchase.message
+  end
+
+  def test_fail_purchase_with_a_repeat_payment
+    auth_with_token = @gateway.purchase(@amount, nil, @options.merge({
+      parent_transaction_reference: 'NON EXISTENT REFERENCE'
+    }))
+
+    assert_failure auth_with_token
+    assert_equal 'ERROR', auth_with_token.message
+  end
+
   def test_failed_purchase
     auth = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure auth


### PR DESCRIPTION
Here there are added tests showing how to purchase with token instead credit card in SecureTrading gateway...

Here there is the documentation followed to implement this.
![Screen Shot 2019-08-27 at 17 58 07](https://user-images.githubusercontent.com/68930/63807536-482d1400-c8f4-11e9-8678-d916d1d602d0.png)
