### PR TITLE
Send ACH/EFT details to Jackson River gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/jackson_river.rb
+++ b/lib/active_merchant/billing/gateways/jackson_river.rb
@@ -65,10 +65,17 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_payment(post, payment)
-        post[:payment_method] = 'credit'
-        post[:card_number] = payment.number
-        post[:card_expiration_month] = payment.month
-        post[:card_expiration_year]  = format(payment.year, :four_digits)
+        if payment.respond_to?(:routing_number)
+          post[:payment_method] = 'bank account'
+          post[:accType] = payment.account_type
+          post[:routingNum] = payment.routing_number
+          post[:accNum] = payment.account_number
+        else
+          post[:payment_method] = 'credit'
+          post[:card_number] = payment.number
+          post[:card_expiration_month] = payment.month
+          post[:card_expiration_year] = format(payment.year, :four_digits)
+        end
       end
 
       def add_metadata(post, options = {})

--- a/test/remote/gateways/remote_jackson_river_test.rb
+++ b/test/remote/gateways/remote_jackson_river_test.rb
@@ -4,17 +4,36 @@ class RemoteJacksonRiverTest < Test::Unit::TestCase
   def setup
     @gateway = JacksonRiverGateway.new(fixtures(:jackson_river))
 
-    @amount = 100
+    @amount = 1000
     @credit_card = credit_card('4111111111111111')
+    @check = check({
+      account_type: ['Checking', 'Corporate', 'Corp Savings'].sample
+    })
     @options = {
       first_name: 'Longbob',
       last_name: 'Longsen',
       billing_address: address,
       description: 'Store Purchase',
-      form_id: 34467,
+      form_id: 34641,
       market_source: 'FooBar_MarketSource',
       canvasser_name: 'John Doe Canvasser'
     }
+  end
+
+  def test_successful_debit_purchase
+    response = @gateway.purchase(@amount, @check, @options)
+    assert_success response
+    assert response.test?
+    assert_equal 'Submission successful', response.message
+    assert_match %r(\d+), response.authorization
+  end
+
+  def test_failed_debit_purchase
+    response = @gateway.purchase(@amount, @check.except(:account_type), @options)
+    assert_failure response
+    assert_equal \
+      'accType::An illegal choice has been detected. Please contact the site administrator.', \
+      response.message
   end
 
   def test_successful_purchase
@@ -47,5 +66,4 @@ class RemoteJacksonRiverTest < Test::Unit::TestCase
     assert_scrubbed(@credit_card.number, transcript)
     assert_scrubbed(@gateway.options[:api_key], transcript)
   end
-
 end


### PR DESCRIPTION
Here there is updated Jackson River Gateway to be able to send debit payments. The new fields are:

* `accType`
* `routingNum`
* `accNum`

and `payment_method` is changed to `'bank account'` when debit payment is trying to be performed