### PR TITLE
Return Apple Pay tokenisation errors

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -190,7 +190,8 @@ module ActiveMerchant #:nodoc:
 
         if payment.is_a?(ApplePayPaymentToken)
           token_exchange_response = tokenize_apple_pay_token(payment)
-          params = { card: token_exchange_response.params["token"]["id"] } if token_exchange_response.success?
+          return token_exchange_response unless token_exchange_response.success?
+          params = { card: token_exchange_response.params["token"]["id"] }
         elsif payment.is_a?(StripePaymentToken)
           add_payment_token(params, payment, options)
         elsif payment.is_a?(Check)

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -52,6 +52,16 @@ class StripeTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_unsuccessful_error_new_customer_with_apple_pay_payment_token
+    @gateway.expects(:tokenize_apple_pay_token).returns(Response.new(false, 'cannot tokenize', token: nil))
+
+    assert response = @gateway.store(@apple_pay_payment_token, @options)
+    assert_instance_of Response, response
+    assert_failure response
+
+    assert_equal 'cannot tokenize', response.message
+  end
+
   def test_successful_new_customer_with_emv_credit_card
     @gateway.expects(:ssl_request).returns(successful_new_customer_response)
 


### PR DESCRIPTION
When creating a customer with an Apple Pay token, the token is first turned into a Stripe token. An error during this step should be returned immediately so that the error message is preserved and so that no attempt is made to create a Stripe customer with invalid data.
