### PR TITLE
Revert the upstream change for CA Cert

### DIFF
--- a/lib/active_merchant/connection.rb
+++ b/lib/active_merchant/connection.rb
@@ -43,7 +43,7 @@ module ActiveMerchant
       @read_timeout = READ_TIMEOUT
       @retry_safe   = RETRY_SAFE
       @verify_peer  = VERIFY_PEER
-      @ca_file      = CA_FILE
+      @ca_file      = nil
       @ca_path      = CA_PATH
       @max_retries  = MAX_RETRIES
       @ignore_http_status = false

--- a/test/unit/connection_test.rb
+++ b/test/unit/connection_test.rb
@@ -125,8 +125,7 @@ class ConnectionTest < Test::Unit::TestCase
   end
 
   def test_default_ca_file
-    assert_equal ActiveMerchant::Connection::CA_FILE, @connection.ca_file
-    assert_equal ActiveMerchant::Connection::CA_FILE, @connection.send(:http).ca_file
+    assert_equal nil, @connection.ca_file
   end
 
   def test_override_ca_file


### PR DESCRIPTION
It seems like the ActiveMerchant ca bundle is way behind the times
and does not contain a lot of new CA authorities as the iATS connections
are all failing. Reverting back to using the OS one which is more
recent and up to date.

Refs waysact/evergiving#3988

Note: I have tested a few remote gateways that have working credentials to verify this still works. I've also verified with the `uk` iATS gateway credentials:

Prior to change:

```
Error: test_successful_store_and_unstore(IatsPaymentsTest): ActiveMerchant::ConnectionError: The SSL connection to the remote server could not be established
```

After change:

```
Finished in 17.973786 seconds.
------------------------------------------------------------------------------------------------------------------------------------------------------------
12 tests, 40 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
83.3333% passed
------------------------------------------------------------------------------------------------------------------------------------------------------------
0.67 tests/s, 2.23 assertions/s
```

where the 2 failures are related to ACH purchases