### PR TITLE
Flo2Cash Rest API update - Use Raw Card Details API integration

### DIFF
--- a/test/unit/gateways/flo2cash_rest_test.rb
+++ b/test/unit/gateways/flo2cash_rest_test.rb
@@ -16,6 +16,7 @@ class Flo2cashRestTest < Test::Unit::TestCase
     @amount = 100
 
     @options = {
+      payment_method_type: 'token',
       order_id: '1',
       billing_address: address,
       description: 'Store Purchase',


### PR DESCRIPTION
### Process Card Payments using Raw Card Details

To do this we are abstracting in a better way the method `add_payment_method`. Now it allows to use Card objects into the payment method payload to do the purchase (i.e. without tokenise the card).

Notice we also keep supporting the other ways to hit this endpoint `/payments` (with token and with iframe)

<img width="568" alt="Screen Shot 2019-10-21 at 16 22 36" src="https://user-images.githubusercontent.com/68930/67236133-09f93000-f41f-11e9-85e9-8bd248dee35f.png">
