### PR TITLE
Show that we can use alternative gateway_id when purchase with Paydock

### DIFF
--- a/lib/active_merchant/billing/gateways/paydock.rb
+++ b/lib/active_merchant/billing/gateways/paydock.rb
@@ -340,10 +340,12 @@ module ActiveMerchant #:nodoc:
         unless success_from(response)
           return STANDARD_ERROR_CODE_MAPPING[:processing_error] unless response['error']
 
-          code = response.dig('error', 'code') || response.dig('error', 'details', 0, 'gateway_specific_code')
+          code = response.dig('error', 'code') ||
+                  response.dig('error', 'details', 0, 'gateway_specific_code') ||
+                  response.dig('error', 'message')
           decline_code = response.dig('error', 'decline_code').try(:to_sym) if code == 'card_declined'
 
-          STANDARD_ERROR_CODE_MAPPING[decline_code] || STANDARD_ERROR_CODE_MAPPING[code.to_sym] || code
+          STANDARD_ERROR_CODE_MAPPING[decline_code || code.try(:to_sym)] || code
         end
       end
 

--- a/test/remote/gateways/remote_paydock_test.rb
+++ b/test/remote/gateways/remote_paydock_test.rb
@@ -68,8 +68,10 @@ class RemotePaydockTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_more_options
+    gateway_id = fixtures(:paydock)[:login]
     options = {
       reference: 'TestReference',
+      gateway_id: gateway_id,
       customer: {
           first_name: 'Joe',
           last_name: 'Blow',


### PR DESCRIPTION
Here there is a small improvement to show errors from Paydock and a test showing we can pass another gateway in the payload to Paydock.

Here is an extract of the payload send in this test...

```
{
  :amount=>"70.00",
  :currency=>"AUD",
  :description=>"Store Purchase",
  :customer=>{
    :email=>"activemerchant@paydock.com",
    :first_name=>"Longbob",
    :last_name=>"Longsen",
    :payment_source=>{
      :card_name=>"Longbob Longsen",
      :card_number=>"4200000000000000",
      :card_ccv=>"123",
      :expire_month=>9,
      :expire_year=>2020,
      :gateway_id=>"5ccad9177a0295264d275a19"
    }
  }
}
```

Notice that `gateway_id` is under `customer` -> `payment_source`. It's where documentation seems to require it https://docs.paydock.com/#add-charges.