### PR TITLE
Add new gateway to Blackbaud Payment API

### DIFF
--- a/lib/active_merchant/billing/gateways/blackbaud_payment_rest.rb
+++ b/lib/active_merchant/billing/gateways/blackbaud_payment_rest.rb
@@ -1,0 +1,201 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class BlackbaudPaymentRestGateway < Gateway
+      self.supported_countries = ['US']
+      self.default_currency = 'USD'
+      self.money_format = :cents
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover]
+
+      self.live_url = 'https://api.sky.blackbaud.com/payments/v1'
+      self.homepage_url = 'http://www.blackbaud.com/'
+      self.display_name = 'Blackbaud BBPS'
+
+      def initialize(options = {})
+        super
+        requires!(options, :api_key)
+        requires!(options, :api_token)
+        requires!(options, :merchant_id)
+        @api_key = options[:api_key]
+        @api_token = options[:api_token]
+        @merchant_id = options[:merchant_id]
+      end
+
+      def headers(options = {})
+        {
+          'X-Accepts' => 'application/json',
+          'Content-Type' => 'application/json',
+          'User-Agent' => "ActiveMerchant/#{ActiveMerchant::VERSION}",
+          'X-Client-IP' => options[:ip] || '',
+          'Bb-Api-Subscription-Key' => @api_key || options[:api_key],
+          'Authorization' => "Bearer #{@api_token || options[:api_token]}",
+        }
+      end
+
+      def store(payment_method, options={})
+        post = {}
+
+        if payment_method.is_a?(Check)
+          add_debit(post, payment_method)
+          endpoint = '/directdebitaccounttokens'
+          
+        elsif payment_method.is_a?(CreditCard)
+          add_credit(post, payment_method)
+          endpoint = '/cardtokens'
+        end
+
+        commit(:post, endpoint, post, options)
+      end
+
+      # Create a charge using a credit card, card token or customer token
+      #
+      # To charge a credit card: purchase([money], [creditcard hash], ...)
+      # To charge a customer, payment_source or vault_token: purchase([money], [authorization], ...)
+      #
+      def purchase(money, payment, options = {})
+        post = {}
+
+        post[:payment_configuration_id] = @merchant_id
+        post[:amount] = amount(money).to_s
+
+        post[:transaction_id] = options[:transaction_id]        
+        post[:email] = options[:email]
+        post[:phone] = options[:phone]
+        post[:comment] = options[:comment]
+
+        add_payment(post, payment, options)
+        add_billing_contact(post, options)
+
+        commit(:post, '/transactions', post, options)
+      end
+
+      def commit(verb, endpoint, data = nil, options = {})
+        begin
+          raw_response = ssl_request(verb, live_url + endpoint, data.to_json, headers(options))
+          response = raw_response.is_a?(Hash) ? raw_response : JSON.parse(raw_response)
+        rescue ActiveMerchant::ResponseError => e
+          response = JSON.parse(e.response.body)
+          response = response.first if response.is_a?(Array)
+        end
+        response.deep_symbolize_keys! if response.is_a?(Hash)
+        succeeded = success_from(endpoint, response)
+
+        Response.new(
+          succeeded,
+          message_from(succeeded, response),
+          response,
+          authorization: authorization_from(succeeded, endpoint, response),
+          error_code: error_code_from(succeeded, response),
+          test: test?
+        )
+      end
+
+      def success_from(action, response)
+        case action
+        when '/cardtokens'
+          response.key?(:card_token)
+        when '/directdebitaccounttokens'
+          response.key?(:direct_debit_account_token)
+        when '/transactions'
+          response.key?(:id)
+        else
+          response.key?(:id)
+        end
+      end
+
+      def authorization_from(succeeded, action, response)
+        if succeeded
+          case action
+          when '/cardtokens'
+            response[:card_token]
+          when '/directdebitaccounttokens'
+            response[:direct_debit_account_token]
+          when '/transactions'
+            response[:id]
+          else
+            response[:id]
+          end
+        end
+      end
+
+      def message_from(succeeded, response)
+        if succeeded
+          response[:id]
+        else
+          error_code_from(succeeded, response)
+        end
+      end
+
+      def error_code_from(succeeded, response)
+        unless succeeded
+          response[:message] || response[:statusCode]
+        end
+      end
+
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript.
+          gsub(/(Authorization: Bearer )([A-Za-z0-9\-\._~\+\/]+=*)/, '\1[FILTERED]').
+          gsub(/(payment_configuration_id\\?\\?\\?":\\?\\?\\?")(\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b)/, '\1[FILTERED]').
+          gsub(/(Bb-Api-Subscription-Key:\s)(\b[0-9a-f]+)/, '\1[FILTERED]').
+          gsub(/(credit_card\\?\\?\\?":{.+\\?\\?\\?"number\\?\\?\\?":\\?\\?\\?")(\d+)/, '\1[FILTERED]')
+      end
+
+      def add_billing_contact(post, options)
+        billing_contact = {
+          first_name: options[:first_name],
+          last_name: options[:last_name],
+          address: options[:address][:address1],
+          city: options[:address][:city],
+          state: options[:address][:state],
+          country: options[:address][:country],
+          post_code: options[:address][:zip],
+        }
+
+        post[:billing_contact] = billing_contact
+      end
+
+      def add_credit(post, credit_card)
+        post[:exp_month] = credit_card.month
+        post[:exp_year] = credit_card.year
+        post[:name] = credit_card.name
+        post[:number] = credit_card.number
+      end
+
+      def add_debit(post, check)
+        post[:direct_debit_account_info] = {
+          account_number: check.account_number,
+          routing_number: check.routing_number,
+          account_holder: "#{check.first_name} #{check.last_name}",
+          check_number: check.number,
+          account_type: check.account_type
+        }
+      end
+
+      def add_payment(post, payment, options)
+        if payment.is_a?(CreditCard)
+          credit_card = {}
+          add_credit(credit_card, payment)
+          post[:credit_card] = credit_card
+          post[:csc] = options[:csc]
+
+        elsif payment.is_a?(Check)
+          direct_debit_account_info = {}
+          add_debit(direct_debit_account_info, payment)
+          post[:direct_debit_account_info] = direct_debit_account_info
+
+        else
+          if options.key?(:card_token)
+            post[:card_token] = options[:card_token]
+          elsif options.key?(:direct_debit_account_token)
+            post[:direct_debit_account_token] = options[:direct_debit_account_token]
+          else
+            post[:card_present] = { swipe_data: options[:swipe_data] }
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -85,6 +85,11 @@ blackbaud_bbps:
   username: username
   password: password
 
+blackbaud_payment_rest:
+  api_key: API_KEY
+  api_token: BEARER_TOKEN
+  merchant_id: MERCHANT_ID
+
 blue_pay:
   login: '100096218902'
   password: 'MBUVE4G1BACMFM4W3XQHUUL2SMQRP.LW'

--- a/test/remote/gateways/remote_blackbaud_payment_rest_test.rb
+++ b/test/remote/gateways/remote_blackbaud_payment_rest_test.rb
@@ -1,0 +1,66 @@
+require 'test_helper'
+
+class RemoteBlackbaudPaymentRestTest < Test::Unit::TestCase
+  def setup
+    @gateway = BlackbaudPaymentRestGateway.new(fixtures(:blackbaud_payment_rest))
+    @amount = 1000
+    @credit_card = credit_card('4242424242424242')
+    @expired_card = credit_card('4000000000000069')
+
+    @options = {
+        first_name: 'Longbob',
+        last_name: 'Longsen',
+        address: address
+    }
+  end
+
+  def test_successful_card_store
+    response = @gateway.store(@credit_card, @options)
+    assert_success response
+    assert_match %r{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}}, response.authorization
+  end
+
+  def test_successful_debit_store
+    response = @gateway.store(check, @options)
+    
+    assert_success response
+    assert_match %r{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}}, response.authorization
+  end
+
+  def test_successful_purchase_with_credit_card
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+  end
+
+  def test_failed_purchase_with_credit_card
+    response = @gateway.purchase(@amount, @expired_card, @options)
+    assert_failure response
+    assert_match 'Expired card', response.message
+  end
+
+  def test_successful_purchase_with_credit_card_token
+    credit_card_stored = @gateway.store(@credit_card, @options)
+    @options[:card_token] = credit_card_stored.authorization
+    response = @gateway.purchase(@amount, nil, @options)
+    assert_success response
+  end
+
+  def test_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card.number, transcript)
+    assert_scrubbed(@gateway.options[:merchant_id], transcript)
+    assert_scrubbed(@gateway.options[:api_key], transcript)
+  end
+
+  # Validation error code: <InvalidUserAgent> Validation error message <Invalid User-Agent string.>
+  #   def test_successful_purchase_with_debit_card_token
+  #     debit_stored = @gateway.store(check, @options)
+  #     @options[:direct_debit_account_token] = debit_stored.authorization
+  #     response = response = @gateway.purchase(@amount, nil, @options)
+  #     assert_success response
+  #   end
+end

--- a/test/unit/gateways/blackbaud_payment_rest_test.rb
+++ b/test/unit/gateways/blackbaud_payment_rest_test.rb
@@ -1,0 +1,151 @@
+require 'test_helper'
+
+class BlackbaudBbpsTest < Test::Unit::TestCase
+  def setup
+    @gateway = BlackbaudPaymentRestGateway.new(api_key: 'foo', api_token: 'bearer', merchant_id: 'bar')
+    @credit_card = credit_card('4242424242424242')
+    @amount = 1000
+
+    @options = {
+      first_name: 'Longbob',
+      last_name: 'Longsen',
+      address: address
+    }
+  end
+
+  def test_successful_store
+    @gateway.expects(:ssl_request).returns(successful_store_response)
+    response = @gateway.store(@credit_card, @options)
+
+    assert_success response
+    assert_equal 'a792c852-9046-4a8d-884a-6915d742a789', response.authorization
+  end
+
+  def test_successful_purchase
+    @gateway.expects(:ssl_request).returns(successful_purchase_response)
+    response = @gateway.purchase(@amount, @credit_card, @options)
+
+    assert_success response
+    assert_equal '280e7cc2-2c39-4040-8fbb-84a29935e801', response.authorization
+  end
+
+  def test_scrub
+    assert @gateway.supports_scrubbing?
+    assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
+  end
+
+  private
+
+def pre_scrubbed
+  <<-'PRE_SCRUBBED'
+  opening connection to api.sky.blackbaud.com:443...\n
+  opened
+starting SSL for api.sky.blackbaud.com:443...
+SSL established, protocol: TLSv1.2, cipher: ECDHE-RSA-AES256-GCM-SHA384
+<- "POST /payments/v1/transactions HTTP/1.1\r\nContent-Type: application/json\r\nX-Accepts: application/json\r\nUser-Agent: ActiveMerchant/1.78.0\r\nX-Client-Ip: \r\nBb-Api-Subscription-Key: 24443892534c48b39499de3be0ec72e4\r\nAuthorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IjREVjZzVkxIM0FtU1JTbUZqMk04Wm5wWHU3WSJ9.eyJuYW1laWQiOiI4M2FmNmNhZi1mZWQwLTQ2YmMtODc4OC1iNTY4ZGE3NjI1M2UiLCJhcHBsaWNhdGlvbmlkIjoiYTkxODA4ZWMtZGU4Zi00Y2JhLWFkNDEtMDU2NzUyOGRmN2Y4IiwiZW52aXJvbm1lbnRpZCI6InAtZXBRSUpmc0NfVXFsemV3MkdZZVVsQSIsImVudmlyb25tZW50bmFtZSI6IlNPUyBDaGlsZHJlblx1MDAyN3MgVmlsbGFnZXMgQ2FuYWRhIEVudmlyb25tZW50IDEiLCJsZWdhbGVudGl0eWlkIjoicC13MFE2UWRMMmZFQ3ZXLVdSLVFCdmtRIiwibGVnYWxlbnRpdHluYW1lIjoiU09TIENoaWxkcmVuXHUwMDI3cyBWaWxsYWdlcyBDYW5hZGEiLCJpc3MiOiJodHRwczovL29hdXRoMi5za3kuYmxhY2tiYXVkLmNvbS8iLCJhdWQiOiJibGFja2JhdWQiLCJleHAiOjE1NzMwNTk5MDYsIm5iZiI6MTU3MzA1NjMwNn0.AUw_CpJEN_t6b0cqeURfxeAd0CT0yxB2PZh3tDktWltepILLNHhKyQDM-wQXBsQTt2vJldJqpU4UWijTBKTjQy9nnLlhoRSTjVcbyDIB--VXePqEIp1p3b611wqYmFZpMGHXA07VbN9GubjJwhj8knRwIj4ALMAoyqmJ3Gdb4SIvmyj-WRdBjmGXzm337i9wSKxrfZ6zpOrdDfCDbpaiSGlroNEnN_xaI8YQ5yCTdEMLhdLLirNOjK7BcpSv2Ds053cDrSwG7bt494iJm40R67t2q1F_bMZdGfXI_vtE7SDoz2tetaDHXWrh3Gk7mcu3rMxQGuhtF695KIOBER7IKA\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nConnection: close\r\nHost: api.sky.blackbaud.com\r\nContent-Length: 412\r\n\r\n"
+<- "{\"payment_configuration_id\":\"8a998a48-8770-4dc8-b31f-5d26fff5f6cd\",\"amount\":\"1000\",\"transaction_id\":null,\"email\":null,\"phone\":null,\"comment\":null,\"credit_card\":{\"exp_month\":9,\"exp_year\":2020,\"name\":\"Longbob Longsen\",\"number\":\"4242424242424242\"},\"csc\":null,\"billing_contact\":{\"first_name\":\"Longbob\",\"last_name\":\"Longsen\",\"address\":\"456 My Street\",\"city\":\"Ottawa\",\"state\":\"ON\",\"country\":\"CA\",\"post_code\":\"K1C2N6\"}}"
+-> "HTTP/1.1 200 OK\r\n"
+-> "Cache-Control: no-cache\r\n"
+-> "Pragma: no-cache\r\n"
+-> "Transfer-Encoding: chunked\r\n"
+-> "Content-Type: application/json; charset=utf-8\r\n"
+-> "Content-Encoding: gzip\r\n"
+-> "Expires: -1\r\n"
+-> "Vary: Accept-Encoding\r\n"
+-> "Request-Context: appId=cid-v1:7c79702c-183f-4ce4-88bc-c966ef838843\r\n"
+-> "Date: Wed, 06 Nov 2019 16:09:40 GMT\r\n"
+-> "Connection: close\r\n"
+-> "\r\n"
+-> "1E4\r\n"
+reading 484 bytes...
+-> "\x1F\x8B\b\x00\x00\x00\x00\x00\x04\x00\x85R\xC1n\x9C0\x10\xFD\x15\xE4k\x17\x05\xB3\xEC\xB6\xCBm\x95\\\xAA6\xC9J\x95z\xB5\x06<,V\x8C\a\xD9&\r\x8A\xF2\xEF\x1DC\xB6m\xAAF\xF5\x01\xCB\xCFof\xDE{\xF8YDz@'jQ\xBC\xAE\xFC\x1F\x9F\xCB\x12\ea4s\xF7\x12;\x89\xBB&\xC7}U\xE6\xD5\xB6\xDA\xE6Pj\xC8?\x16\xBB\xC3\x0E+YT\xBAa.\f4\xB9(j\xC9\xA5\e\x11=\xB8\x00m4\xE4T\x9CG\xE4>\xD7\xE0\xF5\x1D\xC5\x93\xC7\x80L\xDC\x88\xD6\xA36Q\xB5\x8C\x8B\xFAY\xA4\xFD\xC2\xFDn\x020\x03\x9FF5\x90\x8B\xBD\xA8\x0F\xEBiF\xF0\xA2.\x8B\x92gX\bQu41 \xAA\xB2*\xB9\xC0\xC1\x90\xCA\xBF\x92;7\xD4di\xE7a\xE2\x85\xE5i\x9E\xC5j\xC0\xAA\x0E\x99\xC3\xF5\xED\xE4=\xBAvN\xDA\x8E7\xC9\xC28Z\xD3B\xA21v\x82y`\xA1!;\x9E>'\xB54\xA4#_\x88\xB7\xF64\xC44S\xCA\xAB\xFDUY\xC8C&e]\x1C\xEA\xED\xA7\xECx\x9B}(\x8Az\x89R\x93#\xAF\xCC\xA8X\b'\x10\xD6>8\x80\xB1o\xA1\xB1'\x87\xCAMC\x83~ELP\xD6<\xF2\x8C\x0El@neB3\xF9\x80I\x8E\n\x11\xE2\x94J9\xDA\x9B\xF5\x02\x1A\x8B\\\xD6\x18k\x8D;+\xE3:Z\xF251Y\xBD\x8F\x11~\xC0b\x88\xFF\x97_\xDC\x83\x03\x9D\xA0\x918\xD1\x96t\xF2\xF3E^\x97w{\x06\xD3\x84\x04\xDC\xBB\b\xDE\xD0\x82x\xC4\x94D\xB5\xDBg\xB7s\xF6m=s\xCA\x9D\x87I+63\xD9\x98f\x82#7\xF3\xC3\bj\xF4\xF44\xFF\xBA\x11\xCBC\xA0\x96]\xA3^\xB4:\x05N\xA7|^e\xBDK\xED\xCD\xB9W\xDE\x84\x87\xFF2W\xFC\xE2\xE7\xEF\xCB\xD4!\xB4\xE4\xD7\xB7\xB0\x1Cc\xCF%=Y\xBD@\x8Fh)e\xF6N\xFF\x97\xDF\xC9\xFC\x01\xFE\x04\xE0\xBA4Nc\x03\x00\x00"
+read 484 bytes
+reading 2 bytes...
+-> "\r\n"
+read 2 bytes
+-> "0\r\n"
+-> "\r\n"
+Conn close
+  PRE_SCRUBBED
+  end
+
+  def post_scrubbed
+    <<-'POS_SCRUBBED'
+  opening connection to api.sky.blackbaud.com:443...\n
+  opened
+starting SSL for api.sky.blackbaud.com:443...
+SSL established, protocol: TLSv1.2, cipher: ECDHE-RSA-AES256-GCM-SHA384
+<- "POST /payments/v1/transactions HTTP/1.1\r\nContent-Type: application/json\r\nX-Accepts: application/json\r\nUser-Agent: ActiveMerchant/1.78.0\r\nX-Client-Ip: \r\nBb-Api-Subscription-Key: [FILTERED]\r\nAuthorization: Bearer [FILTERED]\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nConnection: close\r\nHost: api.sky.blackbaud.com\r\nContent-Length: 412\r\n\r\n"
+<- "{\"payment_configuration_id\":\"[FILTERED]\",\"amount\":\"1000\",\"transaction_id\":null,\"email\":null,\"phone\":null,\"comment\":null,\"credit_card\":{\"exp_month\":9,\"exp_year\":2020,\"name\":\"Longbob Longsen\",\"number\":\"[FILTERED]\"},\"csc\":null,\"billing_contact\":{\"first_name\":\"Longbob\",\"last_name\":\"Longsen\",\"address\":\"456 My Street\",\"city\":\"Ottawa\",\"state\":\"ON\",\"country\":\"CA\",\"post_code\":\"K1C2N6\"}}"
+-> "HTTP/1.1 200 OK\r\n"
+-> "Cache-Control: no-cache\r\n"
+-> "Pragma: no-cache\r\n"
+-> "Transfer-Encoding: chunked\r\n"
+-> "Content-Type: application/json; charset=utf-8\r\n"
+-> "Content-Encoding: gzip\r\n"
+-> "Expires: -1\r\n"
+-> "Vary: Accept-Encoding\r\n"
+-> "Request-Context: appId=cid-v1:7c79702c-183f-4ce4-88bc-c966ef838843\r\n"
+-> "Date: Wed, 06 Nov 2019 16:09:40 GMT\r\n"
+-> "Connection: close\r\n"
+-> "\r\n"
+-> "1E4\r\n"
+reading 484 bytes...
+-> "\x1F\x8B\b\x00\x00\x00\x00\x00\x04\x00\x85R\xC1n\x9C0\x10\xFD\x15\xE4k\x17\x05\xB3\xEC\xB6\xCBm\x95\\\xAA6\xC9J\x95z\xB5\x06<,V\x8C\a\xD9&\r\x8A\xF2\xEF\x1DC\xB6m\xAAF\xF5\x01\xCB\xCFof\xDE{\xF8YDz@'jQ\xBC\xAE\xFC\x1F\x9F\xCB\x12\ea4s\xF7\x12;\x89\xBB&\xC7}U\xE6\xD5\xB6\xDA\xE6Pj\xC8?\x16\xBB\xC3\x0E+YT\xBAa.\f4\xB9(j\xC9\xA5\e\x11=\xB8\x00m4\xE4T\x9CG\xE4>\xD7\xE0\xF5\x1D\xC5\x93\xC7\x80L\xDC\x88\xD6\xA36Q\xB5\x8C\x8B\xFAY\xA4\xFD\xC2\xFDn\x020\x03\x9FF5\x90\x8B\xBD\xA8\x0F\xEBiF\xF0\xA2.\x8B\x92gX\bQu41 \xAA\xB2*\xB9\xC0\xC1\x90\xCA\xBF\x92;7\xD4di\xE7a\xE2\x85\xE5i\x9E\xC5j\xC0\xAA\x0E\x99\xC3\xF5\xED\xE4=\xBAvN\xDA\x8E7\xC9\xC28Z\xD3B\xA21v\x82y`\xA1!;\x9E>'\xB54\xA4#_\x88\xB7\xF64\xC44S\xCA\xAB\xFDUY\xC8C&e]\x1C\xEA\xED\xA7\xECx\x9B}(\x8Az\x89R\x93#\xAF\xCC\xA8X\b'\x10\xD6>8\x80\xB1o\xA1\xB1'\x87\xCAMC\x83~ELP\xD6<\xF2\x8C\x0El@neB3\xF9\x80I\x8E\n\x11\xE2\x94J9\xDA\x9B\xF5\x02\x1A\x8B\\\xD6\x18k\x8D;+\xE3:Z\xF251Y\xBD\x8F\x11~\xC0b\x88\xFF\x97_\xDC\x83\x03\x9D\xA0\x918\xD1\x96t\xF2\xF3E^\x97w{\x06\xD3\x84\x04\xDC\xBB\b\xDE\xD0\x82x\xC4\x94D\xB5\xDBg\xB7s\xF6m=s\xCA\x9D\x87I+63\xD9\x98f\x82#7\xF3\xC3\bj\xF4\xF44\xFF\xBA\x11\xCBC\xA0\x96]\xA3^\xB4:\x05N\xA7|^e\xBDK\xED\xCD\xB9W\xDE\x84\x87\xFF2W\xFC\xE2\xE7\xEF\xCB\xD4!\xB4\xE4\xD7\xB7\xB0\x1Cc\xCF%=Y\xBD@\x8Fh)e\xF6N\xFF\x97\xDF\xC9\xFC\x01\xFE\x04\xE0\xBA4Nc\x03\x00\x00"
+read 484 bytes
+reading 2 bytes...
+-> "\r\n"
+read 2 bytes
+-> "0\r\n"
+-> "\r\n"
+Conn close
+  POS_SCRUBBED
+  end
+  
+
+  def successful_store_response
+    { "card_token" => "a792c852-9046-4a8d-884a-6915d742a789" }
+  end
+
+  def successful_purchase_response
+    {
+      "token":"00000000-0000-0000-0000-000000000000",
+      "id":"280e7cc2-2c39-4040-8fbb-84a29935e801",
+      "amount":1000,
+      "transaction_type":"CardNotPresent",
+      "credit_card":{
+        "card_type":"Visa",
+        "exp_month":9,
+        "exp_year":2020,
+        "last_four":"4242",
+        "name":"Longbob Longsen"
+      },
+      "additional_fee":0,
+      "currency":"CAD",
+      "application":"Payments API",
+      "comment":"",
+      "transaction_date":"11/6/2019 10:21:58 AM +00:00",
+      "donor_ip_address":"",
+      "email_address":"",
+      "phone_number":"",
+      "is_live":false,
+      "disbursement_status":"NotDisbursable",
+      "billing_info":{
+        "city":"Ottawa",
+        "country":"Canada",
+        "post_code":"K1C2N6",
+        "state":"Ontario",
+        "street":"456 My Street"
+      },
+      "fraud_result":{
+        "anonymous_proxy_result":"NotProcessed",
+        "bin_and_ip_country_result":"NotProcessed",
+        "high_risk_country_result":"NotProcessed",
+        "result_code":"NotProcessed",
+        "risk_score":0,
+        "risk_threshold":0,"velocity_result":"NotProcessed"
+      },
+      "state":"Processed"
+    }
+  end
+end


### PR DESCRIPTION
Here there is implemented a new gateway


```bash
$ ruby -Itest test/remote/gateways/remote_blackbaud_payment_rest_test.rb
Loaded suite test/remote/gateways/remote_blackbaud_payment_rest_test
Started
......
Finished in 18.838971432 seconds.
-----------------------------------------------------------------------------------------------------------------------
6 tests, 11 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-----------------------------------------------------------------------------------------------------------------------
0.32 tests/s, 0.58 assertions/s

$ ruby -Itest test/unit/gateways/blackbaud_payment_rest_test.rb 
Loaded suite test/unit/gateways/blackbaud_payment_rest_test
Started
...
Finished in 0.032268394 seconds.
-----------------------------------------------------------------------------------------------------------------------
3 tests, 8 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-----------------------------------------------------------------------------------------------------------------------
92.97 tests/s, 247.92 assertions/s
```