### PR TITLE
Avoid double insertion of 'direct_debit_account_info' key

### DIFF
--- a/lib/active_merchant/billing/gateways/blackbaud_payment_rest.rb
+++ b/lib/active_merchant/billing/gateways/blackbaud_payment_rest.rb
@@ -182,9 +182,7 @@ module ActiveMerchant #:nodoc:
           post[:csc] = options[:csc]
 
         elsif payment.is_a?(Check)
-          direct_debit_account_info = {}
-          add_debit(direct_debit_account_info, payment)
-          post[:direct_debit_account_info] = direct_debit_account_info
+          add_debit(post, payment)
 
         else
           if options.key?(:card_token)


### PR DESCRIPTION
It's to avoid double insertion of 

```
\"direct_debit_account_info\":{\"direct_debit_account_info\":{\"account_number\"
```