### PR TITLE
Fix unit test suite

### DIFF
--- a/test/unit/gateways/blackbaud_bbps_test.rb
+++ b/test/unit/gateways/blackbaud_bbps_test.rb
@@ -23,7 +23,8 @@ class BlackbaudBbpsTest < Test::Unit::TestCase
     response = @gateway.store(@credit_card, @options)
 
     assert_failure response
-    assert_equal 'Credit card number is not valid.', response.message  end
+    assert_equal 'Credit card number is not valid.', response.message
+  end
 
   def test_scrub
     assert @gateway.supports_scrubbing?

--- a/test/unit/gateways/blackbaud_payment_rest_test.rb
+++ b/test/unit/gateways/blackbaud_payment_rest_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class BlackbaudBbpsTest < Test::Unit::TestCase
+class BlackbaudPaymentRestTest < Test::Unit::TestCase
   def setup
     @gateway = BlackbaudPaymentRestGateway.new(api_key: 'foo', api_token: 'bearer', merchant_id: 'bar')
     @credit_card = credit_card('4242424242424242')


### PR DESCRIPTION
I've mismatch the name of the unit test. This was causing clashing in method names and therefore tests were screwed up. This is to fix the naming