### PR TITLE
Move arguments into Customer key

### DIFF
--- a/lib/active_merchant/billing/gateways/eway_rapid.rb
+++ b/lib/active_merchant/billing/gateways/eway_rapid.rb
@@ -214,9 +214,9 @@ module ActiveMerchant #:nodoc:
 
       def add_customer_data(params, options)
         params['Customer'] ||= {}
-        params['Mobile'] = options.dig(:customer, :mobile)
-        params['Reference'] = options.dig(:customer, :reference)
-        params['Url'] = options.dig(:customer, :url)
+        params['Customer']['Mobile'] = options.dig(:customer, :mobile)
+        params['Customer']['Reference'] = options.dig(:customer, :reference)
+        params['Customer']['Url'] = options.dig(:customer, :url)
         add_address(params['Customer'], (options[:billing_address] || options[:address]), {:email => options[:email]})
         params['ShippingAddress'] = {}
         add_address(params['ShippingAddress'], options[:shipping_address], {:skip_company => true})


### PR DESCRIPTION
As eWay documentation shows https://eway.io/api-v3/#transparent-redirect customer `Mobile`, `Reference` and `Url` should be scoped into `Customer` key

```
customer = EwayRapid::Models::Customer.new
customer.reference = 'A12345'
customer.title = 'Mr.'
customer.first_name = 'John'
customer.last_name = 'Smith'
customer.company_name = 'Company'
customer.job_description = 'Ruby Developer'
customer.phone = '09 889 0986'
customer.mobile = '09 889 0986'
customer.fax = '09 654 1234'
customer.url = 'http://www.ewaypayments.com'
customer.comments = 'customer comment'
customer.customer_device_ip = '127.0.0.1'
customer.email = 'demo@example.org'
```