### PR TITLE
Extend sidecar values in PaymentSolutions gateway. 

### DIFF
--- a/lib/active_merchant/billing/gateways/payment_solutions.rb
+++ b/lib/active_merchant/billing/gateways/payment_solutions.rb
@@ -128,6 +128,18 @@ module ActiveMerchant #:nodoc:
             xml['d4p1'].Name 'field_c6'
             xml['d4p1'].Value options[:sidecar_value]
           end
+          if options[:sidecar_value_t6]
+            xml['d4p1'].NameValuePair do
+              xml['d4p1'].Name 'field_t6'
+              xml['d4p1'].Value '01'
+            end
+          end
+          if options[:sidecar_value_z1]
+            xml['d4p1'].NameValuePair do
+              xml['d4p1'].Name 'field_z1'
+              xml['d4p1'].Value '01'
+            end
+          end
         end
       end
 


### PR DESCRIPTION
Adding the following extensions

- add name `field_t6` with value `01` if custom input tag `no_tmkt` equals "Yes" (it's passed here as `sidecar_value_t6`)
- add name `field_z1` with value `01` if custom_input tag `no_contact` equals "Yes" (it's passed here as `sidecar_value_z1`)

Ref waysact/evergiving#5228