### PR TITLE
Stripe key encoding error fix

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -516,7 +516,7 @@ module ActiveMerchant #:nodoc:
         idempotency_key = options[:idempotency_key]
 
         headers = {
-          "Authorization" => "Basic " + Base64.encode64(key.to_s + ":").strip,
+          "Authorization" => "Basic " + Base64.strict_encode64(key.to_s + ":").strip,
           "User-Agent" => "Stripe/v1 ActiveMerchantBindings/#{ActiveMerchant::VERSION}",
           "Stripe-Version" => api_version(options),
           "X-Stripe-Client-User-Agent" => stripe_client_user_agent(options),

--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -24,6 +24,16 @@ class RemoteStripeTest < Test::Unit::TestCase
     }
   end
 
+  def test_correct_header_encoding
+    stripe = {
+      login: "sk_test_3OD4TdKSIOhDOL2146JJcC79AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    }
+    headers = StripeGateway.new(stripe).send(:headers)
+    basic_auth_encoding = headers['Authorization']
+
+    assert_false basic_auth_encoding.include?("\n")
+  end
+
   def test_transcript_scrubbing
     transcript = capture_transcript(@gateway) do
       @gateway.purchase(@amount, @credit_card, @options)


### PR DESCRIPTION
There is an error when the key used to create the Authorization header is too long 

```
header Authorization has field value "Basic
 aMUgwUlpFQnVZMjlMdmVBOEhiSDl3TjVNa0pJRHJ4OGpPNEsx\nRnNHQ1BJRVp0TklBd25ZMnVpVHJMQjk0ckI3dTI3dXlrR
mFmNXBPU0kxdGh3\n....", this cannot include CR/LF
```

Here is the fix

Ref https://github.com/waysact/evergiving/issues/5898