### PR TITLE
WorldNet Subscriptions

### DIFF
--- a/test/remote/gateways/remote_world_net_test.rb
+++ b/test/remote/gateways/remote_world_net_test.rb
@@ -180,6 +180,45 @@ class RemoteWorldNetTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_recurring_with_stored_subscription
+    options = {
+      order_id: generate_order_id,
+      subscription_name: 'Stored Subscription Test',
+      subscription_description: 'A test stored subscription from the remote test in ActiveMerchant',
+      period_type: 'MONTHLY',
+      length: 0,
+      currency: 'EUR',
+      recurring_amount: @amount,
+      initial_amount: 0,
+      type: 'AUTOMATIC',
+      start_date: Time.now.gmtime.strftime("%d-%m-%Y")
+    }
+
+    response = @gateway.create_stored_subscription(options)
+    options.merge!(stored_subscription_ref: response.authorization)
+    response = @gateway.recurring(@credit_card, options)
+    assert_success response
+  end
+
+  def test_failed_recurring_missing_stored_subscription
+    options = {
+      order_id: generate_order_id,
+      subscription_name: 'Subscription Test',
+      subscription_description: 'A test subscription from the remote test in ActiveMerchant',
+      period_type: 'MONTHLY',
+      length: 0,
+      currency: 'EUR',
+      recurring_amount: @amount,
+      initial_amount: 0,
+      type: 'AUTOMATIC',
+      start_date: Time.now.gmtime.strftime("%d-%m-%Y"),
+      stored_subscription_ref: 'MISSING_SUBSCRIPTION'
+    }
+
+    response = @gateway.recurring(@credit_card, options)
+    assert_failure response
+  end
+
   def test_failed_recurring
     options = {
       order_id: generate_order_id,


### PR DESCRIPTION
WorldNet support

🎫 Ref waysact/evergiving#4465

From https://docs.worldnettps.com/doku.php?id=developer:api_specification:xml_subscription_features
```
The Subscription solution has two big components:

Stored Subscriptions: They act not as subscription, but as templates for multiple subscriptions registered under them...

Subscriptions: Those are the actual subscriptions...
```

Here we decouple the creation of `Stored Subscription` when process a recurring payment