### PR TITLE
Allow to send donor_ip

### DIFF
--- a/lib/active_merchant/billing/gateways/blackbaud_payment_rest.rb
+++ b/lib/active_merchant/billing/gateways/blackbaud_payment_rest.rb
@@ -61,6 +61,7 @@ module ActiveMerchant #:nodoc:
         post[:email] = options[:email]
         post[:phone] = options[:phone]
         post[:comment] = options[:comment]
+        post[:donor_ip] = options[:ip]
 
         add_payment(post, payment, options)
         add_billing_contact(post, options)

--- a/test/remote/gateways/remote_blackbaud_payment_rest_test.rb
+++ b/test/remote/gateways/remote_blackbaud_payment_rest_test.rb
@@ -10,7 +10,8 @@ class RemoteBlackbaudPaymentRestTest < Test::Unit::TestCase
     @options = {
         first_name: 'Longbob',
         last_name: 'Longsen',
-        address: address
+        address: address,
+        ip: '192.168.0.1'
     }
   end
 


### PR DESCRIPTION
Ref waysact/evergiving#6130

Add `donor_ip` to Blackbaud `/transactions` queries ```https://developer.sky.blackbaud.com/docs/services/payments/operations/CreateTransaction```