### PR TITLE
Create WorldpayGlobalBusiness gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/worldpay_global_business.rb
+++ b/lib/active_merchant/billing/gateways/worldpay_global_business.rb
@@ -1,0 +1,279 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class WorldpayGlobalBusinessGateway < Gateway
+      self.test_url = 'https://secure-test.worldpay.com/jsp/merchant/xml/paymentService.jsp'
+      self.live_url = 'https://secure.worldpay.com/jsp/merchant/xml/paymentService.jsp'
+
+      self.default_currency = 'GBP'
+      self.money_format = :cents
+      self.supported_countries = %w(HK GB AU AD BE CH CY CZ DE DK ES FI FR GI GR HU IE IT LI LU MC MT NL NO NZ PL PT SE SG SI SM TR UM VA)
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :jcb, :maestro, :laser, :switch]
+      self.currencies_without_fractions = %w(HUF IDR ISK JPY KRW)
+      self.currencies_with_three_decimal_places = %w(BHD KWD OMR RSD TND)
+      self.homepage_url = 'http://www.worldpay.com/'
+      self.display_name = 'Worldpay Global'
+
+      CARD_CODES = {
+        'visa'             => 'VISA-SSL',
+        'master'           => 'ECMC-SSL',
+        'discover'         => 'DISCOVER-SSL',
+        'american_express' => 'AMEX-SSL',
+        'jcb'              => 'JCB-SSL',
+        'maestro'          => 'MAESTRO-SSL',
+        'laser'            => 'LASER-SSL',
+        'diners_club'      => 'DINERS-SSL',
+        'switch'           => 'MAESTRO-SSL'
+      }
+
+      STANDARD_ERROR_CODE_MAPPING = {
+        '4'   => 'HOLD CARD',
+        '5'   => 'REFUSED',
+        '8'   => 'APPROVE AFTER IDENTIFICATION',
+        '13'  => 'INVALID AMOUNT',
+        '15'  => 'INVALID CARD ISSUER',
+        '17'  => 'ANNULATION BY CLIENT',
+        '28'  => 'ACCESS DENIED',
+        '29'  => 'IMPOSSIBLE REFERENCE NUMBER',
+        '33'  => 'CARD EXPIRED',
+        '34'  => 'FRAUD SUSPICION',
+        '38'  => 'SECURITY CODE EXPIRED',
+        '41'  => 'LOST CARD',
+        '43'  => 'STOLEN CARD, PICK UP',
+        '51'  => 'LIMIT EXCEEDED',
+        '55'  => 'INVALID SECURITY CODE',
+        '56'  => 'UNKNOWN CARD',
+        '57'  => 'ILLEGAL TRANSACTION',
+        '62'  => 'RESTRICTED CARD',
+        '63'  => 'SECURITY RULES VIOLATED',
+        '75'  => 'SECURITY CODE INVALID',
+        '76'  => 'CARD BLOCKED',
+        '85'  => 'REJECTED BY CARD ISSUER',
+        '973' => 'Revocation of authorization order',
+        '975' => 'Revocation of all authorizations order',
+      }
+
+      def initialize(options = {})
+        requires!(options, :username, :password)
+        super
+      end
+
+      def purchase(money, payment_method, options = {})
+        requires!(options, :order_id)
+        capture_request(money, payment_method, options)
+      end
+
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript.
+          gsub(%r((Authorization: Basic )\w+), '\1[FILTERED]').
+          gsub(%r((<cardNumber>)\d+(</cardNumber>)), '\1[FILTERED]\2').
+          gsub(%r((<cvc>)[^<]+(</cvc>)), '\1[FILTERED]\2')
+      end
+
+      private
+
+      def capture_request(money, payment_method, options)
+        commit('authorize', build_capture_request(money, payment_method, options))
+      end
+
+      def build_request
+        xml = Builder::XmlMarkup.new :indent => 2
+        xml.instruct! :xml, :encoding => 'UTF-8'
+        xml.declare! :DOCTYPE, :paymentService, :PUBLIC, "-//WorldPay//DTD WorldPay PaymentService v1//EN", "http://dtd.worldpay.com/paymentService_v1.dtd"
+        xml.tag! 'paymentService', 'version' => "1.4", 'merchantCode' => (@options[:merchant_code] ? @options[:merchant_code] : @options[:username]) do
+          yield xml
+        end
+        xml.target!
+      end
+
+
+      def build_capture_request(money, payment_method, options)
+        build_request do |xml|
+          xml.tag! 'submit' do
+            xml.tag! 'order', 'orderCode' => options[:order_id] do
+              xml.tag! 'description', options[:description].presence || "Purchase"
+              add_amount(xml, money, options)
+              add_payment_method(xml, money, payment_method, options)
+              add_shopper(xml, options)
+            end
+          end
+        end
+      end
+
+      def add_amount(xml, money, options)
+        currency = options[:currency] || currency(money)
+
+        amount_hash = {
+          :value => localized_amount(money, currency),
+          'currencyCode' => currency,
+          'exponent' => currency_exponent(currency)
+        }
+
+        xml.tag! 'amount', amount_hash
+      end
+
+      def add_payment_method(xml, amount, payment_method, options)
+        xml.tag! 'paymentDetails' do
+          xml.tag! 'CARD-SSL' do
+            xml.cardNumber payment_method.number
+            xml.expiryDate do
+              xml.date 'month' => payment_method.month, 'year' => payment_method.year
+            end
+            xml.tag! 'cardHolderName', payment_method.name
+            add_address(xml, (options[:billing_address] || options[:address]))
+          end
+          add_session(xml, options)
+        end
+      end
+
+      def add_session(xml, options)
+        if options[:ip] && options[:session_id]
+          xml.tag! 'session', 'shopperIPAddress' => options[:ip], 'id' => options[:session_id]
+        else
+          xml.tag! 'session', 'shopperIPAddress' => options[:ip] if options[:ip]
+          xml.tag! 'session', 'id' => options[:session_id] if options[:session_id]
+        end
+      end
+
+      def add_shopper(xml, options)
+        return unless options[:email]
+        xml.tag! 'shopper' do
+          xml.tag! 'shopperEmailAddress', options[:email]
+          if options[:user_agent].present?
+            xml.tag! 'browser' do
+              xml.tag! 'acceptHeader', 'text/html'
+              xml.tag! 'userAgentHeader', options[:user_agent]
+            end  
+          end
+        end
+      end
+
+      def add_address(xml, address)
+        return unless address
+
+        address = address_with_defaults(address)
+
+        xml.tag! 'cardAddress' do
+          xml.tag! 'address' do
+            xml.tag! 'address1', address[:address1]
+            xml.tag! 'address2', address[:address2] if address[:address2]
+            xml.tag! 'postalCode', address[:zip]
+            xml.tag! 'city', address[:city]
+            xml.tag! 'state', address[:state]
+            xml.tag! 'countryCode', address[:country]
+          end
+        end
+      end
+
+      def address_with_defaults(address)
+        address ||= {}
+        address.delete_if { |_, v| v.blank? }
+        address.reverse_merge!(default_address)
+      end
+
+      def default_address
+        {
+          address1: 'N/A',
+          zip: '0000',
+          city: 'N/A',
+          state: 'N/A',
+          country: 'US'
+        }
+      end
+
+      def parse(action, xml)
+        parse_element({:action => action}, REXML::Document.new(xml))
+      end
+
+      def parse_element(raw, node)
+        node.attributes.each do |k, v|
+          raw["#{node.name.underscore}_#{k.underscore}".to_sym] = v
+        end
+        if node.has_elements?
+          raw[node.name.underscore.to_sym] = true unless node.name.blank?
+          node.elements.each{|e| parse_element(raw, e) }
+        else
+          raw[node.name.underscore.to_sym] = node.text unless node.text.nil?
+        end
+        raw
+      end
+
+      def headers(options = {})
+        credentials = "#{@options[:username]}:#{@options[:password]}"
+
+        {
+          'Content-Type' => 'text/xml',
+          'Authorization' => 'Basic ' + Base64.strict_encode64(credentials)
+        }
+      end
+
+      def commit(action, request)
+        xmr = ssl_post(url, request, headers)
+        raw = parse(action, xmr)
+        success, message = success_and_message_from(raw)
+
+        Response.new(
+          success,
+          message,
+          raw,
+          :authorization => authorization_from(raw),
+          :error_code => error_code_from(success, raw),
+          :test => test?)
+
+      rescue ActiveMerchant::ResponseError => e
+        if e.response.code.to_s == "401"
+          return Response.new(false, "Invalid credentials", {}, :test => test?)
+        else
+          raise e
+        end
+      end
+
+      def url
+        test? ? self.test_url : self.live_url
+      end
+
+      # success_criteria can be:
+      #   - a string or an array of strings (if one of many responses)
+      #   - An array of strings if one of many responses could be considered a
+      #     success.
+      def success_and_message_from(raw)
+        success = (['AUTHORISED'].include?(raw[:last_event]) || raw[:ok].present?)
+        if success
+          message = "SUCCESS"
+        else
+          message = (raw[:iso8583_return_code_description] || raw[:error] || required_status_message(raw))
+        end
+
+        [ success, message ]
+      end
+
+      def error_code_from(success, raw)
+        unless success == "SUCCESS"
+          code = raw[:iso8583_return_code_code] || raw[:error_code] || nil
+
+          STANDARD_ERROR_CODE_MAPPING.fetch(code, 'ERROR')      
+        end
+      end
+
+      def required_status_message(raw, success_criteria)
+        if(!['AUTHORISED'].include?(raw[:last_event]))
+          "A transaction status of #{success_criteria.collect{|c| "'#{c}'"}.join(" or ")} is required."
+        end
+      end
+
+      def authorization_from(raw)
+        pair = raw.detect{|k,v| k.to_s =~ /_order_code$/}
+        (pair ? pair.last : nil)
+      end
+
+      def currency_exponent(currency)
+        return 0 if non_fractional_currency?(currency)
+        return 3 if three_decimal_currency?(currency)
+        return 2
+      end
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -1350,6 +1350,11 @@ world_pay_gateway_cft:
   login: 'SPREEDLYCFT'
   password: 'Xbf+6#pD'
 
+worldpay_global_business:
+  username: NewUsername
+  password: XMLPassword
+  merchant_code: MERCHANT_ID
+
 worldpay_online_payments:
   client_key: "T_C_b9f629e7-cea7-4edb-8206-24bbe351d699"
   service_key: "T_S_eea7c405-25a9-4428-918f-27a9d63fe64f"

--- a/test/remote/gateways/remote_worldpay_global_business_test.rb
+++ b/test/remote/gateways/remote_worldpay_global_business_test.rb
@@ -1,0 +1,42 @@
+require 'test_helper'
+
+class RemoteWorldpayGlobalBusinessTest < Test::Unit::TestCase
+  def setup
+    @gateway = WorldpayGlobalBusinessGateway.new(fixtures(:worldpay_global_business))
+
+    @amount = 100
+    @credit_card = credit_card('4444333322221111')
+    @declined_card = credit_card('4444333322221111',
+     first_name: '',
+     last_name: 'REFUSED')
+    @options = {
+      billing_address: address,
+      description: 'Store Purchase',
+      order_id: generate_unique_id,
+    }
+  end
+
+  def test_successful_purchase
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'SUCCESS', response.message
+  end
+
+  def test_failed_purchase
+    response = @gateway.purchase(310, @declined_card, @options)
+    assert_failure response
+    assert_equal 'REFUSED', response.message
+  end
+
+  def test_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card.number, transcript)
+    assert_scrubbed(@credit_card.verification_value, transcript)
+    assert_scrubbed(@gateway.options[:password], transcript)
+    assert_scrubbed(@gateway.options[:username], transcript)
+  end
+end

--- a/test/unit/gateways/worldpay_global_business_test.rb
+++ b/test/unit/gateways/worldpay_global_business_test.rb
@@ -1,0 +1,230 @@
+require 'test_helper'
+
+class WorldpayGlobalBusinessTest < Test::Unit::TestCase
+  def setup
+    @gateway = WorldpayGlobalBusinessGateway.new(username: 'login', password: 'password')
+    @credit_card = credit_card
+    @amount = 100
+
+    @options = {
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
+    }
+  end
+
+  def test_successful_purchase
+    @gateway.expects(:ssl_post).returns(successful_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+
+    assert_equal '788f4b4f666771b60aaf074a41ef60d9', response.authorization
+    assert response.test?
+  end
+
+  def test_failed_purchase
+    @gateway.expects(:ssl_post).returns(failed_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    error_expected = WorldpayGlobalBusinessGateway::STANDARD_ERROR_CODE_MAPPING['5']
+    assert_equal error_expected, response.error_code
+  end
+
+
+  def test_scrub
+    assert @gateway.supports_scrubbing?
+    assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
+  end
+
+  private
+
+  def pre_scrubbed
+    <<-PRE_SCRUBBED
+      opening connection to secure-test.worldpay.com:443...
+      opened
+starting SSL for secure-test.worldpay.com:443...
+SSL established, protocol: TLSv1.2, cipher: ECDHE-RSA-AES256-GCM-SHA384
+<- "POST /jsp/merchant/xml/paymentService.jsp HTTP/1.1
+Content-Type: text/xml
+Authorization: Basic RUxETTZRRDVCWVkyWTVER1ZEUUQ6bjE4VCFwM0JUQHR1TiRv
+Accept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+Accept: */*
+User-Agent: Ruby
+Connection: close
+Host: secure-test.worldpay.com
+Content-Length: 1074"
+<- "<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN" "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="UNHCRLAMECOM">
+  <submit>
+    <order orderCode="fdec4e066c1b95ccc934a3dfeccb4d8c">
+      <description>Store Purchase</description>
+      <amount value="100" currencyCode="GBP" exponent="2"/>
+      <paymentDetails>
+        <CARD-SSL>
+          <cardNumber>4444333322221111</cardNumber>
+          <expiryDate>
+            <date month="9" year="2021"/>
+          </expiryDate>
+          <cardHolderName>Longbob Longsen</cardHolderName>
+          <cardAddress>
+            <address>
+              <address1>456 My Street</address1>
+              <address2>Apt 1</address2>
+              <postalCode>K1C2N6</postalCode>
+              <city>Ottawa</city>
+              <state>ON</state>
+              <countryCode>CA</countryCode>
+            </address>
+          </cardAddress>
+        </CARD-SSL>
+      </paymentDetails>
+    </order>
+  </submit>
+  </paymentService>"
+-> "HTTP/1.1 200 OK"
+-> "Date: Mon, 09 Nov 2020 22:14:29 GMT"
+-> "Server: Apache"
+-> "Content-Length: 1035"
+-> "P3P: CP="NON""
+-> "Set-Cookie: machine=0ab20016;path=/"
+-> "Content-Type: text/plain"
+-> "X-XSS-Protection: 1; mode=block"
+-> "X-Content-Type-Options: nosniff"
+-> "Strict-Transport-Security: max-age=3156000; includeSubDomains; preload"
+-> "Connection: close"
+-> ""
+reading 1035 bytes...
+-> "<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+                                "http://dtd.worldpay.com/paymentService_v1.dtd">
+                                <paymentService version="1.4" merchantCode="UNHCRLAMECOM"><reply><orderStatus orderCode="fdec4e066c1b95ccc934a3dfeccb4d8c"><payment><paymentMethod>VISA_CREDIT-SSL</paymentMethod><amount value="100" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/><lastEvent>AUTHORISED</lastEvent><CVCResultCode description="NOT SUPPLIED BY SHOPPER"/><AAVAddressResultCode description="UNKNOWN"/><AAVPostcodeResultCode description="UNKNOWN"/><AAVCardholderNameResultCode description="UNKNOWN"/><AAVTelephoneResultCode description="UNKNOWN"/><AAVEmailResultCode description="UNKNOWN"/><balance accountType="IN_PROCESS_AUTHORISED"><amount value="100" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/></balance><cardNumber>4444********1111</cardNumber><riskScore value="20"/></payment></orderStatus></reply></paymentService>
+"
+read 1035 bytes
+Conn close
+    PRE_SCRUBBED
+  end
+
+  def post_scrubbed
+    <<-POST_SCRUBBED
+      opening connection to secure-test.worldpay.com:443...
+      opened
+starting SSL for secure-test.worldpay.com:443...
+SSL established, protocol: TLSv1.2, cipher: ECDHE-RSA-AES256-GCM-SHA384
+<- "POST /jsp/merchant/xml/paymentService.jsp HTTP/1.1
+Content-Type: text/xml
+Authorization: Basic [FILTERED]
+Accept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+Accept: */*
+User-Agent: Ruby
+Connection: close
+Host: secure-test.worldpay.com
+Content-Length: 1074"
+<- "<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN" "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="UNHCRLAMECOM">
+  <submit>
+    <order orderCode="fdec4e066c1b95ccc934a3dfeccb4d8c">
+      <description>Store Purchase</description>
+      <amount value="100" currencyCode="GBP" exponent="2"/>
+      <paymentDetails>
+        <CARD-SSL>
+          <cardNumber>[FILTERED]</cardNumber>
+          <expiryDate>
+            <date month="9" year="2021"/>
+          </expiryDate>
+          <cardHolderName>Longbob Longsen</cardHolderName>
+          <cardAddress>
+            <address>
+              <address1>456 My Street</address1>
+              <address2>Apt 1</address2>
+              <postalCode>K1C2N6</postalCode>
+              <city>Ottawa</city>
+              <state>ON</state>
+              <countryCode>CA</countryCode>
+            </address>
+          </cardAddress>
+        </CARD-SSL>
+      </paymentDetails>
+    </order>
+  </submit>
+  </paymentService>"
+-> "HTTP/1.1 200 OK"
+-> "Date: Mon, 09 Nov 2020 22:14:29 GMT"
+-> "Server: Apache"
+-> "Content-Length: 1035"
+-> "P3P: CP="NON""
+-> "Set-Cookie: machine=0ab20016;path=/"
+-> "Content-Type: text/plain"
+-> "X-XSS-Protection: 1; mode=block"
+-> "X-Content-Type-Options: nosniff"
+-> "Strict-Transport-Security: max-age=3156000; includeSubDomains; preload"
+-> "Connection: close"
+-> ""
+reading 1035 bytes...
+-> "<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+                                "http://dtd.worldpay.com/paymentService_v1.dtd">
+                                <paymentService version="1.4" merchantCode="UNHCRLAMECOM"><reply><orderStatus orderCode="fdec4e066c1b95ccc934a3dfeccb4d8c"><payment><paymentMethod>VISA_CREDIT-SSL</paymentMethod><amount value="100" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/><lastEvent>AUTHORISED</lastEvent><CVCResultCode description="NOT SUPPLIED BY SHOPPER"/><AAVAddressResultCode description="UNKNOWN"/><AAVPostcodeResultCode description="UNKNOWN"/><AAVCardholderNameResultCode description="UNKNOWN"/><AAVTelephoneResultCode description="UNKNOWN"/><AAVEmailResultCode description="UNKNOWN"/><balance accountType="IN_PROCESS_AUTHORISED"><amount value="100" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/></balance><cardNumber>4444********1111</cardNumber><riskScore value="20"/></payment></orderStatus></reply></paymentService>
+"
+read 1035 bytes
+Conn close
+    POST_SCRUBBED
+  end
+
+  def successful_purchase_response
+    <<-XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+                                      "http://dtd.worldpay.com/paymentService_v1.dtd">
+      <paymentService version="1.4" merchantCode="UNHCRLAMECOM">
+        <reply>
+          <orderStatus orderCode="788f4b4f666771b60aaf074a41ef60d9">
+            <payment>
+              <paymentMethod>VISA_CREDIT-SSL</paymentMethod>
+              <amount value="100" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/>
+              <lastEvent>AUTHORISED</lastEvent>
+              <CVCResultCode description="NOT SUPPLIED BY SHOPPER"/>
+              <AAVAddressResultCode description="UNKNOWN"/><AAVPostcodeResultCode description="UNKNOWN"/>
+              <AAVCardholderNameResultCode description="UNKNOWN"/><AAVTelephoneResultCode description="UNKNOWN"/>
+              <AAVEmailResultCode description="UNKNOWN"/>
+              <balance accountType="IN_PROCESS_AUTHORISED">
+                <amount value="100" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/>
+              </balance>
+              <cardNumber>4444********1111</cardNumber>
+              <riskScore value="20"/>
+            </payment>
+          </orderStatus>
+        </reply>
+      </paymentService>
+    XML
+  end
+
+  def failed_purchase_response
+    <<-XML
+      <!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+                                "http://dtd.worldpay.com/paymentService_v1.dtd">
+      <paymentService version="1.4" merchantCode="UNHCRLAMECOM">
+        <reply>
+          <orderStatus orderCode="4a514d32fed6762e0bce38f74bfe3abc">
+            <payment>
+              <paymentMethod>VISA_CREDIT-SSL</paymentMethod>
+              <amount value="310" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/>
+              <lastEvent>REFUSED</lastEvent>
+              <ISO8583ReturnCode code="5" description="REFUSED"/>
+              <CVCResultCode description="NOT SUPPLIED BY SHOPPER"/>
+              <AAVAddressResultCode description="UNKNOWN"/>
+              <AAVPostcodeResultCode description="UNKNOWN"/>
+              <AAVCardholderNameResultCode description="UNKNOWN"/>
+              <AAVTelephoneResultCode description="UNKNOWN"/>
+              <AAVEmailResultCode description="UNKNOWN"/>
+              <riskScore value="20"/>
+            </payment>
+          </orderStatus>
+        </reply>
+      </paymentService>
+    XML
+  end
+end


### PR DESCRIPTION
Here is implemented a new gateway `WorldpayGlobalBusinessGateway` with only `purchase` implementation as required in Ref waysact/evergiving#6182.


Remote tests passing...

```
ruby -Itest test/remote/gateways/remote_worldpay_global_business_test.rbLoaded suite test/remote/gateways/remote_worldpay_global_business_test
Started
...
Finished in 6.523812895 seconds.
---------------------------------------------------------------------------------------------------------------------
3 tests, 8 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
---------------------------------------------------------------------------------------------------------------------
```