### PR TITLE
Change format amount sent to Seerbit. Ref waysact/evergiving#6445

### DIFF
--- a/lib/active_merchant/billing/gateways/seerbit.rb
+++ b/lib/active_merchant/billing/gateways/seerbit.rb
@@ -11,7 +11,7 @@ module ActiveMerchant #:nodoc:
       self.default_currency = 'GHS'
 
       self.supported_cardtypes = [:visa, :mastercard, :maestro]
-      self.money_format = :dollars
+      self.money_format = :cents
 
       #
       #  00 - success - Purchase without 3DS
@@ -62,8 +62,6 @@ module ActiveMerchant #:nodoc:
 
         commit("/payments/charge", post)
       end
-
-
 
       def recurring(money, payment, options = {})
         post = {}

--- a/test/remote/gateways/remote_seerbit_test.rb
+++ b/test/remote/gateways/remote_seerbit_test.rb
@@ -4,7 +4,7 @@ class RemoteSeerbitTest < Test::Unit::TestCase
   def setup
     @gateway = SeerbitGateway.new(fixtures(:seerbit))
 
-    @amount = 10000
+    @amount = 100
     @credit_card = credit_card('5123450000000008', {
       month: '05',
       year: '21',


### PR DESCRIPTION
we only need to send the whole amount without cents and without `.`