### PR TITLE
Implementation of Wompi Gateway. 

### DIFF
--- a/lib/active_merchant/billing/gateways/wompi.rb
+++ b/lib/active_merchant/billing/gateways/wompi.rb
@@ -1,0 +1,246 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class WompiGateway < Gateway
+      self.test_url = 'https://sandbox.wompi.co/v1'
+      self.live_url = 'https://production.wompi.co/v1'
+
+      self.supported_countries = ['CO']
+      self.default_currency = 'COP'
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover]
+
+      self.homepage_url = 'https://wompi.co/'
+      self.display_name = 'Wompi'
+
+      self.money_format = :cents
+
+      PAYMENT_SOURCE_TYPES = %w[ CARD NEQUI ]
+
+      def initialize(options={})
+        requires!(options, :public_key, :private_key)
+
+        super
+      end
+
+      def store(payment_method, options={})
+        post = {}
+
+        post[:number] = payment_method.number
+        post[:cvc] = payment_method.verification_value
+        post[:exp_month] = format(payment_method.month, :two_digits)
+        post[:exp_year] = format(payment_method.year, :two_digits)
+        post[:card_holder] = payment_method.name
+
+        commit(:post, '/tokens/cards', post)
+      end
+
+      def purchase(money, payment, options={})
+        post = {}
+        post[:acceptance_token] = acceptance_token
+
+        add_invoice(post, money, options)
+        add_payment(post, payment, options)
+        add_address(post, payment, options)
+        add_customer_data(post, options)
+
+        commit(:post, '/transactions', post)
+      end
+
+      # Lookup transaction using reference or using transaction id path parans
+      #
+      def query_transaction(reference, options={})
+        if options[:path_params] && reference.present?
+          commit(:get, "/transactions/#{reference}")
+        else
+          commit(:get, "/transactions?reference=#{reference}")
+        end
+      end
+
+      def pse_financial_institutions
+        commit(:get, "/pse/financial_institutions")
+      end
+
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript.
+          gsub(/(Authorization: Bearer )([A-Za-z0-9\-\._~\+\/]+=*)/, '\1[FILTERED]').
+          gsub(/(\\?\\?\\?"number\\?\\?\\?":\\?\\?\\?")\d+/, '\1[FILTERED]').
+          gsub(/(\\?\\?\\?"cvc\\?\\?\\?":\\?\\?\\?"?)\d+/, '\1[FILTERED]')
+      end
+
+      private
+
+      def add_customer_data(post, options)
+        post[:customer_data] = {}
+        post[:customer_data][:phone_number] = options[:customer]&.[](:mob_phone)
+        post[:customer_data][:full_name] = options[:customer]&.[](:full_name)
+        post[:customer_email] = options[:customer]&.[](:email)
+        post[:redirect_url] = options[:redirect_url]
+      end
+
+      def add_address(post, creditcard, options)
+        post[:shipping_address] = add_address_data(options)
+      end
+
+      def add_address_data(options)
+        address = {}
+
+        if options[:address].present?
+          address[:address_line_1] = options[:address][:address1]
+          address[:address_line_2] = options[:address][:address2]
+          address[:city] = options[:address][:city]
+          address[:region] = options[:address][:state]
+          address[:name] = options[:customer]&.[](:full_name)
+          address[:phone_number] = options[:customer]&.[](:mob_phone)
+          address[:postal_code] = options[:address][:postal_code]
+          address[:country] = options[:address][:country]
+        end
+
+        address
+      end
+
+      def add_invoice(post, money, options)
+        post[:amount_in_cents] = amount(money).to_i
+        post[:currency] = (options[:currency] || currency(money))
+        post[:reference] = options[:reference]
+      end
+
+      def add_payment(post, payment, options)
+        post[:payment_method] = {}
+        post[:payment_method][:type] = "CARD"
+        post[:payment_method][:token] = options[:token]
+        post[:payment_method][:installments] = options[:installments] || 1
+      end
+
+      def parse(body)
+        JSON.parse(body)
+      end
+
+      def headers(action)
+        key = reference_in_params?(action) ? :private_key : :public_key
+
+        {
+          'accept' => '*/*',
+          'Content-Type' => 'application/json',
+          'Authorization' => "Bearer #{@options.send(:[], key)}"
+        }
+      end
+
+      def reference_in_params?(action)
+        action.match(/\A?reference=[^&]+&*/).present?
+      end
+
+      def commit(verb, action, parameters={})
+        endpoint = url + action
+
+        begin
+          params = post_data(action, parameters)
+          response = parse(ssl_request(verb, endpoint, params, headers(action)))
+        rescue ResponseError => e
+          response = parse(e.response.body)
+        end
+
+        success = success_from(action, response)
+
+        Response.new(
+          success,
+          message_from(success, action, response),
+          response,
+          authorization: authorization_from(action, response),
+          test: test?,
+          error_code: error_code_from(success, response)
+        )
+      end
+
+      def success_from(action, response)
+        case action
+        when '/tokens/cards'
+          response['status'] == 'CREATED'
+
+        when /\/merchants\/pub_(test|prod)_.+/
+          response['data']['presigned_acceptance']['acceptance_token']
+
+        when '/transactions'
+          data = response['data']
+          response_data = data.is_a?(Array) ? data.first : data
+          [ 'PENDING', 'APPROVED' ].include?(response_data&.[]('status'))
+
+        when '/pse/financial_institutions'
+          response['data'].is_a?(Array) && !response['data'].empty?
+        end
+      end
+
+      def message_from(success, endpoint, response)
+        case endpoint
+        when '/tokens/cards'
+          if success
+            response.fetch('status')
+          else
+            response
+              .dig('error', 'messages').map { |k, v| "#{k}: #{v.join}" }
+              .join
+          end
+
+        when /\/merchants\/pub_(test|prod)_\w+/
+          response.dig('data', 'presigned_acceptance', 'acceptance_token')
+
+        when '/pse/financial_institutions'
+          'APPROVED' if response['data'].is_a?(Array) && !response['data'].empty?
+
+        else
+          data = response['data']
+          response_data = data.is_a?(Array) ? data.first : data
+
+          response_data&.[]('status')
+        end
+      end
+
+      def authorization_from(endpoint, response)
+        data = response['data']
+        response_data = data.is_a?(Array) ? data.first : data
+
+        response_data&.[]('id')
+      end
+
+      def post_data(action, parameters = {})
+        parameters.empty? ? nil : parameters.to_json
+      end
+
+      def error_code_from(success, response)
+        unless success
+          error_type = response['error']&.[]('type')
+
+          data = response['data']
+          response_data = data.is_a?(Array) ? data.first : data
+
+          error_type || response_data&.[]('status')
+        end
+      end
+
+      def url
+        test? ? test_url : live_url
+      end
+
+      # This is a previous query before each query needed to get a bearer token
+      # https://docs.wompi.co/docs/en/tokens-de-aceptacion
+      def acceptance_token
+        action = "/merchants/#{@options[:public_key]}"
+        endpoint = url + action
+
+        response = parse(ssl_get(endpoint, headers(action)))
+
+        get_token(success_from(action, response), response)
+      end
+
+      def get_token(success, response)
+        if success
+          response.dig('data', 'presigned_acceptance', 'acceptance_token')
+        else
+          raise "Failed authorization: #{raw_response}"
+        end
+      end
+    end
+  end
+end

--- a/lib/active_merchant/billing/gateways/wompi.rb
+++ b/lib/active_merchant/billing/gateways/wompi.rb
@@ -21,6 +21,12 @@ module ActiveMerchant #:nodoc:
         super
       end
 
+      def query_acceptance_token
+        action = "/merchants/#{@options[:public_key]}"
+
+        commit(:get, action)
+      end
+
       def store(payment_method, options={})
         post = {}
 
@@ -35,7 +41,7 @@ module ActiveMerchant #:nodoc:
 
       def purchase(money, payment, options={})
         post = {}
-        post[:acceptance_token] = acceptance_token
+        post[:acceptance_token] = query_acceptance_token.message
 
         add_invoice(post, money, options)
         add_payment(post, payment, options)
@@ -220,23 +226,6 @@ module ActiveMerchant #:nodoc:
 
       def url
         test? ? test_url : live_url
-      end
-
-      def acceptance_token
-        action = "/merchants/#{@options[:public_key]}"
-        endpoint = url + action
-
-        response = parse(ssl_get(endpoint, headers(action)))
-
-        get_token(success_from(action, response), response)
-      end
-
-      def get_token(success, response)
-        if success
-          response.dig('data', 'presigned_acceptance', 'acceptance_token')
-        else
-          raise "Failed authorization: #{raw_response}"
-        end
       end
 
       def reference_in_params?(action)

--- a/lib/active_merchant/billing/gateways/wompi.rb
+++ b/lib/active_merchant/billing/gateways/wompi.rb
@@ -234,7 +234,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def reference_in_params?(action)
-        path_params_ref?(action) || query_string_ref?(action.split('?').last)
+        action_uri = URI(action)
+        path_params_ref?(action_uri.path) || query_string_ref?(action_uri.query)
       end
 
       def path_params_ref?(action)

--- a/lib/active_merchant/billing/gateways/wompi.rb
+++ b/lib/active_merchant/billing/gateways/wompi.rb
@@ -71,7 +71,7 @@ module ActiveMerchant #:nodoc:
 
       def scrub(transcript)
         transcript.
-          gsub(/(Authorization: Bearer )([^\s])+/, '\1[FILTERED]').
+          gsub(/\b(Authorization:\s+Bearer\s+)\S+/, '\1[FILTERED]').
           gsub(/(\\?\\?\\?"number\\?\\?\\?":\\?\\?\\?")\d+/, '\1[FILTERED]').
           gsub(/(\\?\\?\\?"cvc\\?\\?\\?":\\?\\?\\?"?)\d+/, '\1[FILTERED]')
       end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -1447,6 +1447,10 @@ wirecard_checkout_page:
   shop_id: ''
   paymenttype: IDL
 
+wompi:
+  public_key: PUBLIC_KEY
+  private_key: PRIVATE_KEY
+
 # Working credentials, no need to replace
 world_net:
   terminal_id: '6001'

--- a/test/remote/gateways/remote_wompi_test.rb
+++ b/test/remote/gateways/remote_wompi_test.rb
@@ -4,7 +4,7 @@ class RemoteWompiTest < Test::Unit::TestCase
   def setup
     @gateway = WompiGateway.new(fixtures(:wompi))
 
-    @amount = 1000000
+    @amount = 1_000_000
     @credit_card = credit_card('4242424242424242')
     @declined_card = credit_card('4111111111111111')
     @options = {
@@ -13,10 +13,10 @@ class RemoteWompiTest < Test::Unit::TestCase
       reference: SecureRandom.uuid,
       currency: 'COP',
       customer: {
-        email: "john.smith@test.com",
+        email: 'john.smith@test.com',
         full_name: 'John smith',
-        mob_phone: '08032000001'
-      }
+        mob_phone: '08032000001',
+      },
     }
   end
 
@@ -36,37 +36,30 @@ class RemoteWompiTest < Test::Unit::TestCase
   def test_fail_store
     response = @gateway.store(credit_card('4'), @options)
     assert_failure response
-    assert_equal "number: debe coincidir con el patron \"^\\d{12,19}$\"", response.message
+    assert_equal "number: debe coincidir con el patron \"^\\d{12,19}$\"",
+                 response.message
+  end
+
+  def test_approved_purchase
+    purchase_response = @gateway.purchase(@amount, @credit_card, @options)
+
+    response =
+      @gateway.query_transaction(purchase_response.params['data']['reference'])
+
+    assert_equal 'APPROVED', response.message
   end
 
   def test_pending_purchase
-    tokenizations_response = @gateway.store(@credit_card, @options)
-    options = @options.merge(token: tokenizations_response.authorization)
-    response = @gateway.purchase(@amount, @credit_card, options)
+    response = @gateway.purchase(@amount, @credit_card, @options)
 
-    assert_success response
     assert_equal 'PENDING', response.message
   end
 
   def test_failed_purchase
-    tokenizations_response = @gateway.store(@declined_card, @options)
-    options = @options.merge(token: tokenizations_response.authorization)
-
-    purchase_response = @gateway.purchase(@amount, @declined_card, options)
-    assert_success purchase_response
-
-    response = @gateway.query_transaction(purchase_response.params['data']['reference'])
+    purchase_response = @gateway.purchase(@amount, @declined_card, @options)
+    response =
+      @gateway.query_transaction(purchase_response.params['data']['reference'])
     assert_equal 'DECLINED', response.message
-  end
-
-  def test_approved_purchase
-    tokenizations_response = @gateway.store(@credit_card, @options)
-    options = @options.merge(token: tokenizations_response.authorization)
-    purchase_response = @gateway.purchase(@amount, @credit_card, options)
-
-    response = @gateway.query_transaction(purchase_response.params['data']['reference'])
-
-    assert_equal 'APPROVED', response.message
   end
 
   def test_financial_institutions
@@ -76,16 +69,20 @@ class RemoteWompiTest < Test::Unit::TestCase
   end
 
   def test_transcript_scrubbing
-    transcript = capture_transcript(@gateway) do
-      tokenizations_response = @gateway.store(@credit_card, @options)
-      options = @options.merge(token: tokenizations_response.authorization)
-      response = @gateway.purchase(@amount, @credit_card, options)
-    end
+    transcript =
+      capture_transcript(@gateway) do
+        tokenizations_response = @gateway.store(@credit_card, @options)
+        options = @options.merge(token: tokenizations_response.authorization)
+        response = @gateway.purchase(@amount, @credit_card, options)
+      end
 
     transcript = @gateway.scrub(transcript)
 
     assert_scrubbed(@credit_card.number, transcript)
-    assert_scrubbed(/(\\?\\?\\?"cvv\\?\\?\\?":\\?\\?\\?"?)#{@credit_card.verification_value}+/, transcript)
+    assert_scrubbed(
+      /(\\?\\?\\?"cvv\\?\\?\\?":\\?\\?\\?"?)#{@credit_card.verification_value}+/,
+      transcript,
+    )
     assert_scrubbed(@gateway.options[:private_key], transcript)
   end
 end

--- a/test/remote/gateways/remote_wompi_test.rb
+++ b/test/remote/gateways/remote_wompi_test.rb
@@ -20,6 +20,12 @@ class RemoteWompiTest < Test::Unit::TestCase
     }
   end
 
+  def test_query_acceptance_token
+    response = @gateway.query_acceptance_token
+    assert_success response
+    assert_match /.{20}\..{284}\..{43}/, response.message
+  end
+
   def test_successful_store
     response = @gateway.store(@credit_card, @options)
     assert_success response

--- a/test/remote/gateways/remote_wompi_test.rb
+++ b/test/remote/gateways/remote_wompi_test.rb
@@ -1,0 +1,85 @@
+require 'test_helper'
+
+class RemoteWompiTest < Test::Unit::TestCase
+  def setup
+    @gateway = WompiGateway.new(fixtures(:wompi))
+
+    @amount = 1000000
+    @credit_card = credit_card('4242424242424242')
+    @declined_card = credit_card('4111111111111111')
+    @options = {
+      address: address({ country: 'CO' }),
+      description: 'Store Purchase',
+      reference: SecureRandom.uuid,
+      currency: 'COP',
+      customer: {
+        email: "john.smith@test.com",
+        full_name: 'John smith',
+        mob_phone: '08032000001'
+      }
+    }
+  end
+
+  def test_successful_store
+    response = @gateway.store(@credit_card, @options)
+    assert_success response
+    assert_equal 'CREATED', response.message
+    assert_match /tok_test_\d{4}_[a-zA-Z0-9]{32}/, response.authorization
+  end
+
+  def test_fail_store
+    response = @gateway.store(credit_card('4'), @options)
+    assert_failure response
+    assert_equal "number: debe coincidir con el patron \"^\\d{12,19}$\"", response.message
+  end
+
+  def test_pending_purchase
+    tokenizations_response = @gateway.store(@credit_card, @options)
+    options = @options.merge(token: tokenizations_response.authorization)
+    response = @gateway.purchase(@amount, @credit_card, options)
+
+    assert_success response
+    assert_equal 'PENDING', response.message
+  end
+
+  def test_failed_purchase
+    tokenizations_response = @gateway.store(@declined_card, @options)
+    options = @options.merge(token: tokenizations_response.authorization)
+
+    purchase_response = @gateway.purchase(@amount, @declined_card, options)
+    assert_success purchase_response
+
+    response = @gateway.query_transaction(purchase_response.params['data']['reference'])
+    assert_equal 'DECLINED', response.message
+  end
+
+  def test_approved_purchase
+    tokenizations_response = @gateway.store(@credit_card, @options)
+    options = @options.merge(token: tokenizations_response.authorization)
+    purchase_response = @gateway.purchase(@amount, @credit_card, options)
+
+    response = @gateway.query_transaction(purchase_response.params['data']['reference'])
+
+    assert_equal 'APPROVED', response.message
+  end
+
+  def test_financial_institutions
+    response = @gateway.pse_financial_institutions
+
+    assert_equal 'APPROVED', response.message
+  end
+
+  def test_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      tokenizations_response = @gateway.store(@credit_card, @options)
+      options = @options.merge(token: tokenizations_response.authorization)
+      response = @gateway.purchase(@amount, @credit_card, options)
+    end
+
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card.number, transcript)
+    assert_scrubbed(/(\\?\\?\\?"cvv\\?\\?\\?":\\?\\?\\?"?)#{@credit_card.verification_value}+/, transcript)
+    assert_scrubbed(@gateway.options[:private_key], transcript)
+  end
+end

--- a/test/unit/gateways/wompi_test.rb
+++ b/test/unit/gateways/wompi_test.rb
@@ -2,54 +2,91 @@ require 'test_helper'
 
 class WompiTest < Test::Unit::TestCase
   def setup
-    @gateway = WompiGateway.new(public_key: 'pub_test_key', private_key: 'priv_test_key')
+    @gateway =
+      WompiGateway.new(public_key: 'pub_test_key', private_key: 'priv_test_key')
     @credit_card = credit_card
     @amount = 100
 
     @options = {
       order_id: '1',
       billing_address: address,
-      description: 'Store Purchase'
+      description: 'Store Purchase',
     }
   end
 
   def test_acceptance_token
-    @gateway.expects(:ssl_request).with(:get, any_parameters).returns(acceptance_token_response)
+    @gateway
+      .expects(:ssl_request)
+      .with(:get, any_parameters)
+      .returns(acceptance_token_response)
 
     response = @gateway.query_acceptance_token
     assert_success response
   end
 
   def test_successful_purchase
-    @gateway.expects(:ssl_request)
+    @gateway
+      .expects(:store)
+      .with(any_parameters)
+      .returns(success_store_response)
+    @gateway
+      .expects(:ssl_request)
       .with(:get, any_parameters)
       .returns(acceptance_token_response)
-    @gateway.expects(:ssl_request)
+    @gateway
+      .expects(:ssl_request)
       .with(:post, any_parameters)
       .returns(successful_purchase_response)
+    @gateway
+      .expects(:query_transaction)
+      .with(any_parameters)
+      .returns(success_query_transaction_response)
 
     response = @gateway.purchase(@amount, @credit_card, @options)
-    assert_success response
 
-    assert_equal '18020-1612330162-69314', response.authorization
+    assert_equal 'PENDING', response.error_code
+    assert_equal '18020-1613658963-86049', response.authorization
     assert response.test?
+
+    query_transaction_response =
+      @gateway.query_transaction('31ca6742-ee1f-4216-bbb3-4dbc9a08a264')
+
+    assert_equal 'APPROVED', query_transaction_response.message
   end
 
   def test_failed_purchase
-    @gateway.expects(:ssl_request)
+    @gateway
+      .expects(:store)
+      .with(any_parameters)
+      .returns(success_store_response)
+    @gateway
+      .expects(:ssl_request)
       .with(:get, any_parameters)
       .returns(acceptance_token_response)
-    @gateway.expects(:ssl_request)
+    @gateway
+      .expects(:ssl_request)
       .with(:post, any_parameters)
       .returns(failed_purchase_response)
+    @gateway
+      .expects(:query_transaction)
+      .with(any_parameters)
+      .returns(failed_query_transaction_response)
 
     response = @gateway.purchase(@amount, @credit_card, @options)
+
     assert_failure response
-    assert_equal 'DECLINED', response.error_code
+    assert_equal 'PENDING', response.error_code
+
+    query_transaction_response =
+      @gateway.query_transaction('f1ddd87d-afe1-49d8-964b-39191053f2c1')
+
+    assert_equal 'DECLINED', query_transaction_response.message
   end
 
   def test_successful_financial_institution_gathering
-    @gateway.expects(:ssl_request).returns(successful_financial_institutions_response)
+    @gateway
+      .expects(:ssl_request)
+      .returns(successful_financial_institutions_response)
 
     response = @gateway.pse_financial_institutions
     assert_success response
@@ -121,33 +158,6 @@ class WompiTest < Test::Unit::TestCase
   end
 
   def acceptance_token_response
-    # response = JSON.parse('{
-    #   "data":{
-    #     "id":8020,
-    #     "name":"Fondo de las Naciones Unidas para la Infancia",
-    #     "email":"ikerguelen@unicef.org",
-    #     "contact_name":"Idual Kerguelen",
-    #     "phone_number":"+573118889793",
-    #     "active":true,
-    #     "logo_url":null,
-    #     "legal_name":"Fondo de las Naciones Unidas para la Infancia",
-    #     "legal_id_type":"NIT",
-    #     "legal_id":"800176994-3",
-    #     "public_key":"pub_test_rxLNy4HKU8geG0Nh2SJuEknZf5plwB0I",
-    #     "accepted_currencies":["COP"],
-    #     "fraud_javascript_key":"zzzzz",
-    #     "accepted_payment_methods":["BANCOLOMBIA_TRANSFER", "NEQUI", "PSE", "CARD", "BANCOLOMBIA_COLLECT"],
-    #     "presigned_acceptance":{
-    #       "acceptance_token":"eyJhbGciOiJIUzI1NiJ9.eyJjb250cmFjdF9pZCI6MSwicGVybWFsaW5rIjoiaHR0cHM6Ly93b21waS5jby93cC1jb250ZW50L3VwbG9hZHMvMjAxOS8wOS9URVJNSU5PUy1ZLUNPTkRJQ0lPTkVTLURFLVVTTy1VU1VBUklPUy1XT01QSS5wZGYiLCJmaWxlX2hhc2giOiIzZGNkMGM5OGU3NGFhYjk3OTdjZmY3ODExNzMxZjc3YiIsImppdCI6IjE2MTI0NDU2NjctNDUyNTciLCJleHAiOjE2MTI0NDkyNjd9.0keZVJbWeN2T83mrZvGQ0goSDUO2Tp6ff4f9hKzlyPE",
-    #       "permalink":"https://wompi.co/wp-content/uploads/2019/09/TERMINOS-Y-CONDICIONES-DE-USO-USUARIOS-WOMPI.pdf",
-    #       "type":"END_USER_POLICY"
-    #     }
-    #   },
-    #   "meta":{}
-    # }')
-
-    # Response.new(true, 'APPROVED', response, authorization: response.dig('data', 'presigned_acceptance', 'acceptance_token'))
-
     '{
       "data":{
         "id":8020,
@@ -174,59 +184,84 @@ class WompiTest < Test::Unit::TestCase
     }'
   end
 
-  def successful_purchase_response
-    '{
-      "data":[
-        {
-          "id":"18020-1612330162-69314",
-          "created_at":"2021-02-03T05:29:23.017Z",
-          "amount_in_cents":1000000,
-          "reference":"988178d0-4711-4dc5-91e6-3ee7d59d204e",
-          "customer_email":"john.smith@test.com",
-          "currency":"COP",
-          "payment_method_type":"CARD",
-          "payment_method":{
-            "type":"CARD",
-            "extra":{
-              "bin":"424242",
-              "name":"VISA-4242",
-              "brand":"VISA",
-              "exp_year":"22",
-              "exp_month":"09",
-              "last_four":"4242",
-              "external_identifier":"xmzeOjDePy"},
-            "token":"tok_test_8020_4D0e205EC281049d201d9A0445e213d0",
-            "installments":1},
-          "status":"APPROVED",
-          "status_message":null,
-          "shipping_address":{
-            "address_line_1":"456 My Street",
-            "address_line_2":"Apt 1",
-            "city":"Ottawa",
-            "region":"ON",
-            "name":"John smith",
-            "phone_number":"08032000001",
-            "postal_code":null,
-            "country":"CO"},
-          "redirect_url":null,
-          "payment_source_id":null,
-          "payment_link_id":null,
-          "customer_data":{
-            "full_name":"John smith",
-            "phone_number":"08032000001"
-          }}],
-        "meta":{}
+  def success_store_response
+    raw_response =
+      '{
+        "status": "CREATED",
+        "data": {
+          "id": "tok_test_8020_A9Bdc8e874944a478c6ea8e242aa0114",
+          "created_at": "2021-02-18T17:32:29.611+00:00",
+          "brand": "VISA",
+          "name": "VISA-1111",
+          "last_four": "1111",
+          "bin": "411111",
+          "exp_year": "22",
+          "exp_month": "09",
+          "card_holder": "Longbob Longsen",
+          "expires_at": "2021-08-17T17:32:29.000Z"
+        }
       }'
+
+    create_active_merchant_response(raw_response)
   end
 
-  def failed_purchase_response
+  def successful_purchase_response
     '{
+      "data":{
+        "id":"18020-1613658963-86049",
+        "created_at":"2021-02-18T14:36:03.646Z",
+        "amount_in_cents":1000000,
+        "reference":"31ca6742-ee1f-4216-bbb3-4dbc9a08a264",
+        "customer_email":"john.smith@test.com",
+        "currency":"COP",
+        "payment_method_type":"CARD",
+        "payment_method":{
+          "type":"CARD",
+          "extra":{
+            "bin":"424242",
+            "name":"VISA-4242",
+            "brand":"VISA",
+            "exp_year":"22",
+            "exp_month":"09",
+            "last_four":"4242"
+          },
+          "installments":1
+        },
+        "status":"PENDING",
+        "status_message":null,
+        "shipping_address":{
+          "address_line_1":"456 My Street",
+          "address_line_2":"Apt 1",
+          "city":"Ottawa",
+          "region":"ON",
+          "name":"John smith",
+          "phone_number":"08032000001",
+          "postal_code":null,
+          "country":"CO"
+        },
+        "redirect_url":null,
+        "payment_source_id":null,
+        "payment_link_id":null,
+        "customer_data":{
+          "full_name":"John smith",
+          "phone_number":"08032000001"
+        },
+        "bill_id":null,
+        "taxes":[]
+      },
+      "meta":{}
+    }'
+  end
+
+  def failed_query_transaction_response
+    raw_response =
+      '{
       "data":[
         {
-          "id":"18020-1612331980-99648",
-          "created_at":"2021-02-03T05:59:40.329Z",
+          "id":"18020-1613645528-18530",
+          "created_at":"2021-02-18T10:52:08.218Z",
           "amount_in_cents":1000000,
-          "reference":"cdbd9a99-d06c-41c2-b536-70bb476d6130",
+          "reference":"f1ddd87d-afe1-49d8-964b-39191053f2c1",
           "customer_email":"john.smith@test.com",
           "currency":"COP",
           "payment_method_type":"CARD",
@@ -238,11 +273,62 @@ class WompiTest < Test::Unit::TestCase
             "exp_year":"22",
             "exp_month":"09",
             "last_four":"1111",
-            "external_identifier":"72TdupPphv"},
-          "token":"tok_test_8020_f770448fd9CE667AD29EaCa8f9c61333",
-          "installments":1},
-          "status":"DECLINED",
-          "status_message":"La transacción fue rechazada (Sandbox)",
+            "external_identifier":"DLGR2zsdWv"
+          },
+          "token":"tok_test_8020_84Ecda6A12E4976f9D85194688AD593e",
+          "installments":1
+        },
+        "status":"DECLINED",
+        "status_message":"La transacci\xC3\xB3n fue rechazada (Sandbox)",
+        "shipping_address":{
+          "address_line_1":"456 My Street",
+          "address_line_2":"Apt 1",
+          "city":"Ottawa",
+          "region":"ON",
+          "name":"John smith",
+          "phone_number":"08032000001",
+          "postal_code":null,
+          "country":"CO"},
+          "redirect_url":null,
+          "payment_source_id":null,
+          "payment_link_id":null,
+          "customer_data":{
+            "full_name":"John smith",
+            "phone_number":"08032000001"
+        }}],
+        "meta":{}
+      }'
+
+    create_active_merchant_response(raw_response)
+  end
+
+  def success_query_transaction_response
+    raw_response =
+      '{
+        "data":[
+          {
+            "id":"18020-1613658963-86049",
+            "created_at":"2021-02-18T14:36:03.646Z",
+            "amount_in_cents":1000000,
+            "reference":"31ca6742-ee1f-4216-bbb3-4dbc9a08a264",
+            "customer_email":"john.smith@test.com",
+            "currency":"COP",
+            "payment_method_type":"CARD",
+            "payment_method":{
+              "type":"CARD",
+              "extra":{"bin":"424242",
+              "name":"VISA-4242",
+              "brand":"VISA",
+              "exp_year":"22",
+              "exp_month":"09",
+              "last_four":"4242",
+              "external_identifier":"QR3kN04BsP"
+            },
+            "token":"tok_test_8020_3d76d3Ceb92d6C47109dDF2b12eFc647",
+            "installments":1
+          },
+          "status":"APPROVED",
+          "status_message":null,
           "shipping_address":{
             "address_line_1":"456 My Street",
             "address_line_2":"Apt 1",
@@ -251,15 +337,77 @@ class WompiTest < Test::Unit::TestCase
             "name":"John smith",
             "phone_number":"08032000001",
             "postal_code":null,
-            "country":"CO"},
+            "country":"CO"
+          },
           "redirect_url":null,
           "payment_source_id":null,
           "payment_link_id":null,
           "customer_data":{
             "full_name":"John smith",
-            "phone_number":"08032000001"}
-        }
-      ],
+            "phone_number":"08032000001"
+          }}],
+          "meta":{}
+        }'
+
+    create_active_merchant_response(raw_response)
+  end
+
+  def create_active_merchant_response(response)
+     parsed_response = JSON.parse(response)
+    Response.new(
+      true,
+      @gateway.send(
+        :message_from,
+        '/transactions?reference=id',
+        parsed_response,
+      ),
+      parsed_response,
+    )
+  end
+
+  def failed_purchase_response
+    '{
+      "data":{
+        "id":"18020-1613645528-18530",
+        "created_at":"2021-02-18T10:52:08.218Z",
+        "amount_in_cents":1000000,
+        "reference":"f1ddd87d-afe1-49d8-964b-39191053f2c1",
+        "customer_email":"john.smith@test.com",
+        "currency":"COP",
+        "payment_method_type":"CARD",
+        "payment_method":{
+          "type":"CARD",
+          "extra":{"bin":"411111",
+          "name":"VISA-1111",
+          "brand":"VISA",
+          "exp_year":"22",
+          "exp_month":"09",
+          "last_four":"1111"
+        },
+        "installments":1
+      },
+      "status":"PENDING",
+      "status_message":null,
+      "shipping_address":{
+        "address_line_1":"456 My Street",
+        "address_line_2":"Apt 1",
+        "city":"Ottawa",
+        "region":"ON",
+        "name":"John smith",
+        "phone_number":"08032000001",
+        "postal_code":null,
+        "country":"CO"
+      },
+      "redirect_url":null,
+      "payment_source_id":null,
+      "payment_link_id":null,
+      "customer_data":{
+        "full_name":"John smith",
+        "phone_number":"08032000001"
+      },
+      "bill_id":null,
+      "taxes":[]
+      },
       "meta":{}
     }'
   end

--- a/test/unit/gateways/wompi_test.rb
+++ b/test/unit/gateways/wompi_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class WompiTest < Test::Unit::TestCase
   def setup
-    @gateway = WompiGateway.new(public_key: 'login', private_key: 'password')
+    @gateway = WompiGateway.new(public_key: 'pub_test_key', private_key: 'priv_test_key')
     @credit_card = credit_card
     @amount = 100
 
@@ -13,9 +13,20 @@ class WompiTest < Test::Unit::TestCase
     }
   end
 
+  def test_acceptance_token
+    @gateway.expects(:ssl_request).with(:get, any_parameters).returns(acceptance_token_response)
+
+    response = @gateway.query_acceptance_token
+    assert_success response
+  end
+
   def test_successful_purchase
-    @gateway.expects(:acceptance_token).returns('123')
-    @gateway.expects(:ssl_request).returns(successful_purchase_response)
+    @gateway.expects(:ssl_request)
+      .with(:get, any_parameters)
+      .returns(acceptance_token_response)
+    @gateway.expects(:ssl_request)
+      .with(:post, any_parameters)
+      .returns(successful_purchase_response)
 
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
@@ -25,8 +36,12 @@ class WompiTest < Test::Unit::TestCase
   end
 
   def test_failed_purchase
-    @gateway.expects(:acceptance_token).returns('123')
-    @gateway.expects(:ssl_request).returns(failed_purchase_response)
+    @gateway.expects(:ssl_request)
+      .with(:get, any_parameters)
+      .returns(acceptance_token_response)
+    @gateway.expects(:ssl_request)
+      .with(:post, any_parameters)
+      .returns(failed_purchase_response)
 
     response = @gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
@@ -79,32 +94,84 @@ class WompiTest < Test::Unit::TestCase
   end
 
   def post_scrubbed
-    <<~'POST_SCRUBBED'
-      opening connection to sandbox.wompi.co:443...
-      opened
-      starting SSL for sandbox.wompi.co:443...
-      SSL established, protocol: TLSv1.3, cipher: TLS_AES_128_GCM_SHA256
-      <- "POST /v1/tokens/cards HTTP/1.1\r\nContent-Type: application/json\r\nAccept: */*\r\nAuthorization: Bearer [FILTERED]\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: sandbox.wompi.co\r\nContent-Length: 106\r\n\r\n"
-      <- "{\"number\":\"[FILTERED]\",\"cvc\":\"[FILTERED]\",\"exp_month\":\"09\",\"exp_year\":\"22\",\"card_holder\":\"Longbob Longsen\"}"
-      -> "HTTP/1.1 201 Created\r\n"
-      -> "Content-Type: application/json\r\n"
-      -> "Content-Length: 301\r\n"
-      -> "Connection: close\r\n"
-      -> "Date: Wed, 03 Feb 2021 05:47:35 GMT\r\n"
-      -> "x-amzn-RequestId: 422a3b67-ebc0-4548-9623-c3ab5d7fc2dd\r\n"
-      -> "Access-Control-Allow-Origin: *\r\n"
-      -> "x-amz-apigw-id: aJ3WhHF5oAMFnFQ=\r\n"
-      -> "X-Amzn-Trace-Id: Root=1-601a38f6-4cc8e48520ebcd0d62d636e3;Sampled=0\r\n"
-      -> "X-Cache: Miss from cloudfront\r\n"
-      -> "Via: 1.1 786adf19b53b584c0a277661acb7690d.cloudfront.net (CloudFront)\r\n"
-      -> "X-Amz-Cf-Pop: MIA3-C1\r\n"
-      -> "X-Amz-Cf-Id: D6fj2PCoZ7U9zYAL-1BTYKaYwMqIooTUaeFLvwvMFMjuuLo55zWAEQ==\r\n"
-      -> "\r\n"
-      reading 301 bytes...
-      -> "{\"status\":\"CREATED\",\"data\":{\"id\":\"tok_test_8020_3E8Ff29600Db6EB81727F110d26BaEE4\",\"created_at\":\"2021-02-03T05:47:35.306+00:00\",\"brand\":\"VISA\",\"name\":\"VISA-4242\",\"last_four\":\"4242\",\"bin\":\"424242\",\"exp_year\":\"22\",\"exp_month\":\"09\",\"card_holder\":\"Longbob Longsen\",\"expires_at\":\"2021-08-02T05:47:34.000Z\"}}"
-      read 301 bytes
-      Conn close
-    POST_SCRUBBED
+    "opening connection to sandbox.wompi.co:443...\n" +
+    "opened\n" +
+    "starting SSL for sandbox.wompi.co:443...\n" +
+    "SSL established, protocol: TLSv1.3, cipher: TLS_AES_128_GCM_SHA256\n" +
+    "<- \"POST /v1/tokens/cards HTTP/1.1\\r\\nContent-Type: application/json\\r\\nAccept: */*\\r\\nAuthorization: Bearer [FILTERED] gzip;q=1.0,deflate;q=0.6,identity;q=0.3\\r\\nUser-Agent: Ruby\\r\\nConnection: close\\r\\nHost: sandbox.wompi.co\\r\\nContent-Length: 106\\r\\n\\r\\n\"\n" +
+    "<- \"{\\\"number\\\":\\\"[FILTERED]\\\",\\\"cvc\\\":\\\"[FILTERED]\\\",\\\"exp_month\\\":\\\"09\\\",\\\"exp_year\\\":\\\"22\\\",\\\"card_holder\\\":\\\"Longbob Longsen\\\"}\"\n" +
+    "-> \"HTTP/1.1 201 Created\\r\\n\"\n" +
+    "-> \"Content-Type: application/json\\r\\n\"\n" +
+    "-> \"Content-Length: 301\\r\\n\"\n" +
+    "-> \"Connection: close\\r\\n\"\n" +
+    "-> \"Date: Wed, 03 Feb 2021 05:47:35 GMT\\r\\n\"\n" +
+    "-> \"x-amzn-RequestId: 422a3b67-ebc0-4548-9623-c3ab5d7fc2dd\\r\\n\"\n" +
+    "-> \"Access-Control-Allow-Origin: *\\r\\n\"\n" +
+    "-> \"x-amz-apigw-id: aJ3WhHF5oAMFnFQ=\\r\\n\"\n" +
+    "-> \"X-Amzn-Trace-Id: Root=1-601a38f6-4cc8e48520ebcd0d62d636e3;Sampled=0\\r\\n\"\n" +
+    "-> \"X-Cache: Miss from cloudfront\\r\\n\"\n" +
+    "-> \"Via: 1.1 786adf19b53b584c0a277661acb7690d.cloudfront.net (CloudFront)\\r\\n\"\n" +
+    "-> \"X-Amz-Cf-Pop: MIA3-C1\\r\\n\"\n" +
+    "-> \"X-Amz-Cf-Id: D6fj2PCoZ7U9zYAL-1BTYKaYwMqIooTUaeFLvwvMFMjuuLo55zWAEQ==\\r\\n\"\n" +
+    "-> \"\\r\\n\"\n" +
+    "reading 301 bytes...\n" +
+    "-> \"{\\\"status\\\":\\\"CREATED\\\",\\\"data\\\":{\\\"id\\\":\\\"tok_test_8020_3E8Ff29600Db6EB81727F110d26BaEE4\\\",\\\"created_at\\\":\\\"2021-02-03T05:47:35.306+00:00\\\",\\\"brand\\\":\\\"VISA\\\",\\\"name\\\":\\\"VISA-4242\\\",\\\"last_four\\\":\\\"4242\\\",\\\"bin\\\":\\\"424242\\\",\\\"exp_year\\\":\\\"22\\\",\\\"exp_month\\\":\\\"09\\\",\\\"card_holder\\\":\\\"Longbob Longsen\\\",\\\"expires_at\\\":\\\"2021-08-02T05:47:34.000Z\\\"}}\"\n" +
+    "read 301 bytes\n" +
+    "Conn close\n"
+  end
+
+  def acceptance_token_response
+    # response = JSON.parse('{
+    #   "data":{
+    #     "id":8020,
+    #     "name":"Fondo de las Naciones Unidas para la Infancia",
+    #     "email":"ikerguelen@unicef.org",
+    #     "contact_name":"Idual Kerguelen",
+    #     "phone_number":"+573118889793",
+    #     "active":true,
+    #     "logo_url":null,
+    #     "legal_name":"Fondo de las Naciones Unidas para la Infancia",
+    #     "legal_id_type":"NIT",
+    #     "legal_id":"800176994-3",
+    #     "public_key":"pub_test_rxLNy4HKU8geG0Nh2SJuEknZf5plwB0I",
+    #     "accepted_currencies":["COP"],
+    #     "fraud_javascript_key":"zzzzz",
+    #     "accepted_payment_methods":["BANCOLOMBIA_TRANSFER", "NEQUI", "PSE", "CARD", "BANCOLOMBIA_COLLECT"],
+    #     "presigned_acceptance":{
+    #       "acceptance_token":"eyJhbGciOiJIUzI1NiJ9.eyJjb250cmFjdF9pZCI6MSwicGVybWFsaW5rIjoiaHR0cHM6Ly93b21waS5jby93cC1jb250ZW50L3VwbG9hZHMvMjAxOS8wOS9URVJNSU5PUy1ZLUNPTkRJQ0lPTkVTLURFLVVTTy1VU1VBUklPUy1XT01QSS5wZGYiLCJmaWxlX2hhc2giOiIzZGNkMGM5OGU3NGFhYjk3OTdjZmY3ODExNzMxZjc3YiIsImppdCI6IjE2MTI0NDU2NjctNDUyNTciLCJleHAiOjE2MTI0NDkyNjd9.0keZVJbWeN2T83mrZvGQ0goSDUO2Tp6ff4f9hKzlyPE",
+    #       "permalink":"https://wompi.co/wp-content/uploads/2019/09/TERMINOS-Y-CONDICIONES-DE-USO-USUARIOS-WOMPI.pdf",
+    #       "type":"END_USER_POLICY"
+    #     }
+    #   },
+    #   "meta":{}
+    # }')
+
+    # Response.new(true, 'APPROVED', response, authorization: response.dig('data', 'presigned_acceptance', 'acceptance_token'))
+
+    '{
+      "data":{
+        "id":8020,
+        "name":"Fondo de las Naciones Unidas para la Infancia",
+        "email":"ikerguelen@unicef.org",
+        "contact_name":"Idual Kerguelen",
+        "phone_number":"+573118889793",
+        "active":true,
+        "logo_url":null,
+        "legal_name":"Fondo de las Naciones Unidas para la Infancia",
+        "legal_id_type":"NIT",
+        "legal_id":"800176994-3",
+        "public_key":"pub_test_rxLNy4HKU8geG0Nh2SJuEknZf5plwB0I",
+        "accepted_currencies":["COP"],
+        "fraud_javascript_key":"zzzzz",
+        "accepted_payment_methods":["BANCOLOMBIA_TRANSFER", "NEQUI", "PSE", "CARD", "BANCOLOMBIA_COLLECT"],
+        "presigned_acceptance":{
+          "acceptance_token":"eyJhbGciOiJIUzI1NiJ9.eyJjb250cmFjdF9pZCI6MSwicGVybWFsaW5rIjoiaHR0cHM6Ly93b21waS5jby93cC1jb250ZW50L3VwbG9hZHMvMjAxOS8wOS9URVJNSU5PUy1ZLUNPTkRJQ0lPTkVTLURFLVVTTy1VU1VBUklPUy1XT01QSS5wZGYiLCJmaWxlX2hhc2giOiIzZGNkMGM5OGU3NGFhYjk3OTdjZmY3ODExNzMxZjc3YiIsImppdCI6IjE2MTI0NDU2NjctNDUyNTciLCJleHAiOjE2MTI0NDkyNjd9.0keZVJbWeN2T83mrZvGQ0goSDUO2Tp6ff4f9hKzlyPE",
+          "permalink":"https://wompi.co/wp-content/uploads/2019/09/TERMINOS-Y-CONDICIONES-DE-USO-USUARIOS-WOMPI.pdf",
+          "type":"END_USER_POLICY"
+        }
+      },
+      "meta":{}
+    }'
   end
 
   def successful_purchase_response

--- a/test/unit/gateways/wompi_test.rb
+++ b/test/unit/gateways/wompi_test.rb
@@ -1,0 +1,215 @@
+require 'test_helper'
+
+class WompiTest < Test::Unit::TestCase
+  def setup
+    @gateway = WompiGateway.new(public_key: 'login', private_key: 'password')
+    @credit_card = credit_card
+    @amount = 100
+
+    @options = {
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase'
+    }
+  end
+
+  def test_successful_purchase
+    @gateway.expects(:acceptance_token).returns('123')
+    @gateway.expects(:ssl_request).returns(successful_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+
+    assert_equal '18020-1612330162-69314', response.authorization
+    assert response.test?
+  end
+
+  def test_failed_purchase
+    @gateway.expects(:acceptance_token).returns('123')
+    @gateway.expects(:ssl_request).returns(failed_purchase_response)
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal 'DECLINED', response.error_code
+  end
+
+  def test_successful_financial_institution_gathering
+    @gateway.expects(:ssl_request).returns(successful_financial_institutions_response)
+
+    response = @gateway.pse_financial_institutions
+    assert_success response
+
+    assert response.test?
+  end
+
+  def test_scrub
+    assert @gateway.supports_scrubbing?
+    assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
+  end
+
+  private
+
+  def pre_scrubbed
+    <<~'PRE_SCRUBBED'
+      opening connection to sandbox.wompi.co:443...
+      opened
+      starting SSL for sandbox.wompi.co:443...
+      SSL established, protocol: TLSv1.3, cipher: TLS_AES_128_GCM_SHA256
+      <- "POST /v1/tokens/cards HTTP/1.1\r\nContent-Type: application/json\r\nAccept: */*\r\nAuthorization: Bearer pub_test_rxLNy4HKU8geG0Nh2SJuEknZf5plwB0I\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: sandbox.wompi.co\r\nContent-Length: 106\r\n\r\n"
+      <- "{\"number\":\"4242424242424242\",\"cvc\":\"123\",\"exp_month\":\"09\",\"exp_year\":\"22\",\"card_holder\":\"Longbob Longsen\"}"
+      -> "HTTP/1.1 201 Created\r\n"
+      -> "Content-Type: application/json\r\n"
+      -> "Content-Length: 301\r\n"
+      -> "Connection: close\r\n"
+      -> "Date: Wed, 03 Feb 2021 05:47:35 GMT\r\n"
+      -> "x-amzn-RequestId: 422a3b67-ebc0-4548-9623-c3ab5d7fc2dd\r\n"
+      -> "Access-Control-Allow-Origin: *\r\n"
+      -> "x-amz-apigw-id: aJ3WhHF5oAMFnFQ=\r\n"
+      -> "X-Amzn-Trace-Id: Root=1-601a38f6-4cc8e48520ebcd0d62d636e3;Sampled=0\r\n"
+      -> "X-Cache: Miss from cloudfront\r\n"
+      -> "Via: 1.1 786adf19b53b584c0a277661acb7690d.cloudfront.net (CloudFront)\r\n"
+      -> "X-Amz-Cf-Pop: MIA3-C1\r\n"
+      -> "X-Amz-Cf-Id: D6fj2PCoZ7U9zYAL-1BTYKaYwMqIooTUaeFLvwvMFMjuuLo55zWAEQ==\r\n"
+      -> "\r\n"
+      reading 301 bytes...
+      -> "{\"status\":\"CREATED\",\"data\":{\"id\":\"tok_test_8020_3E8Ff29600Db6EB81727F110d26BaEE4\",\"created_at\":\"2021-02-03T05:47:35.306+00:00\",\"brand\":\"VISA\",\"name\":\"VISA-4242\",\"last_four\":\"4242\",\"bin\":\"424242\",\"exp_year\":\"22\",\"exp_month\":\"09\",\"card_holder\":\"Longbob Longsen\",\"expires_at\":\"2021-08-02T05:47:34.000Z\"}}"
+      read 301 bytes
+      Conn close
+    PRE_SCRUBBED
+  end
+
+  def post_scrubbed
+    <<~'POST_SCRUBBED'
+      opening connection to sandbox.wompi.co:443...
+      opened
+      starting SSL for sandbox.wompi.co:443...
+      SSL established, protocol: TLSv1.3, cipher: TLS_AES_128_GCM_SHA256
+      <- "POST /v1/tokens/cards HTTP/1.1\r\nContent-Type: application/json\r\nAccept: */*\r\nAuthorization: Bearer [FILTERED]\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: sandbox.wompi.co\r\nContent-Length: 106\r\n\r\n"
+      <- "{\"number\":\"[FILTERED]\",\"cvc\":\"[FILTERED]\",\"exp_month\":\"09\",\"exp_year\":\"22\",\"card_holder\":\"Longbob Longsen\"}"
+      -> "HTTP/1.1 201 Created\r\n"
+      -> "Content-Type: application/json\r\n"
+      -> "Content-Length: 301\r\n"
+      -> "Connection: close\r\n"
+      -> "Date: Wed, 03 Feb 2021 05:47:35 GMT\r\n"
+      -> "x-amzn-RequestId: 422a3b67-ebc0-4548-9623-c3ab5d7fc2dd\r\n"
+      -> "Access-Control-Allow-Origin: *\r\n"
+      -> "x-amz-apigw-id: aJ3WhHF5oAMFnFQ=\r\n"
+      -> "X-Amzn-Trace-Id: Root=1-601a38f6-4cc8e48520ebcd0d62d636e3;Sampled=0\r\n"
+      -> "X-Cache: Miss from cloudfront\r\n"
+      -> "Via: 1.1 786adf19b53b584c0a277661acb7690d.cloudfront.net (CloudFront)\r\n"
+      -> "X-Amz-Cf-Pop: MIA3-C1\r\n"
+      -> "X-Amz-Cf-Id: D6fj2PCoZ7U9zYAL-1BTYKaYwMqIooTUaeFLvwvMFMjuuLo55zWAEQ==\r\n"
+      -> "\r\n"
+      reading 301 bytes...
+      -> "{\"status\":\"CREATED\",\"data\":{\"id\":\"tok_test_8020_3E8Ff29600Db6EB81727F110d26BaEE4\",\"created_at\":\"2021-02-03T05:47:35.306+00:00\",\"brand\":\"VISA\",\"name\":\"VISA-4242\",\"last_four\":\"4242\",\"bin\":\"424242\",\"exp_year\":\"22\",\"exp_month\":\"09\",\"card_holder\":\"Longbob Longsen\",\"expires_at\":\"2021-08-02T05:47:34.000Z\"}}"
+      read 301 bytes
+      Conn close
+    POST_SCRUBBED
+  end
+
+  def successful_purchase_response
+    '{
+      "data":[
+        {
+          "id":"18020-1612330162-69314",
+          "created_at":"2021-02-03T05:29:23.017Z",
+          "amount_in_cents":1000000,
+          "reference":"988178d0-4711-4dc5-91e6-3ee7d59d204e",
+          "customer_email":"john.smith@test.com",
+          "currency":"COP",
+          "payment_method_type":"CARD",
+          "payment_method":{
+            "type":"CARD",
+            "extra":{
+              "bin":"424242",
+              "name":"VISA-4242",
+              "brand":"VISA",
+              "exp_year":"22",
+              "exp_month":"09",
+              "last_four":"4242",
+              "external_identifier":"xmzeOjDePy"},
+            "token":"tok_test_8020_4D0e205EC281049d201d9A0445e213d0",
+            "installments":1},
+          "status":"APPROVED",
+          "status_message":null,
+          "shipping_address":{
+            "address_line_1":"456 My Street",
+            "address_line_2":"Apt 1",
+            "city":"Ottawa",
+            "region":"ON",
+            "name":"John smith",
+            "phone_number":"08032000001",
+            "postal_code":null,
+            "country":"CO"},
+          "redirect_url":null,
+          "payment_source_id":null,
+          "payment_link_id":null,
+          "customer_data":{
+            "full_name":"John smith",
+            "phone_number":"08032000001"
+          }}],
+        "meta":{}
+      }'
+  end
+
+  def failed_purchase_response
+    '{
+      "data":[
+        {
+          "id":"18020-1612331980-99648",
+          "created_at":"2021-02-03T05:59:40.329Z",
+          "amount_in_cents":1000000,
+          "reference":"cdbd9a99-d06c-41c2-b536-70bb476d6130",
+          "customer_email":"john.smith@test.com",
+          "currency":"COP",
+          "payment_method_type":"CARD",
+          "payment_method":{
+            "type":"CARD",
+            "extra":{"bin":"411111",
+            "name":"VISA-1111",
+            "brand":"VISA",
+            "exp_year":"22",
+            "exp_month":"09",
+            "last_four":"1111",
+            "external_identifier":"72TdupPphv"},
+          "token":"tok_test_8020_f770448fd9CE667AD29EaCa8f9c61333",
+          "installments":1},
+          "status":"DECLINED",
+          "status_message":"La transacción fue rechazada (Sandbox)",
+          "shipping_address":{
+            "address_line_1":"456 My Street",
+            "address_line_2":"Apt 1",
+            "city":"Ottawa",
+            "region":"ON",
+            "name":"John smith",
+            "phone_number":"08032000001",
+            "postal_code":null,
+            "country":"CO"},
+          "redirect_url":null,
+          "payment_source_id":null,
+          "payment_link_id":null,
+          "customer_data":{
+            "full_name":"John smith",
+            "phone_number":"08032000001"}
+        }
+      ],
+      "meta":{}
+    }'
+  end
+
+  def successful_financial_institutions_response
+    '{
+      "data":[
+        {
+          "financial_institution_code":"1",
+          "financial_institution_name":"Banco que aprueba"
+        },
+        {
+          "financial_institution_code":"2",
+          "financial_institution_name":"Banco que rechaza"
+        }
+      ],
+      "meta":{}
+    }'
+  end
+end


### PR DESCRIPTION
Here is a first round to implement Wompi gateway.

There are implemented

  * `store` method to get a token to use in subsequent requests
  * `purchase` to run a transaction (they have output PENDING generally)
  * `query_transaction` to see how is the status of transactions
  * `pse_financial_institutions` to query the financial institutions availables

ref: https://docs.wompi.co/docs/en/inicio-rapido

Here the remote test
```
$ ruby -Itest test/remote/gateways/remote_wompi_test.rb 
Loaded suite test/remote/gateways/remote_wompi_test
Started
........
Finished in 24.592320023 seconds.
-----------------------------------------------------------------------------------------------------------------------
8 tests, 16 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-----------------------------------------------------------------------------------------------------------------------
0.33 tests/s, 0.65 assertions/s
```

Ref waysact/evergiving#6379