### PR TITLE
Add support for EngagingNetworks

### DIFF
--- a/lib/active_merchant/billing/gateways/engaging_networks.rb
+++ b/lib/active_merchant/billing/gateways/engaging_networks.rb
@@ -294,36 +294,24 @@ module ActiveMerchant #:nodoc:
 
       # private
       def success_from(action, response)
-        case action
-        when 'auth'
-          response.key?('ens-auth-token')
-        else
-          response['status'] == 'SUCCESS'
-        end
+        action == 'auth' ? response.key?('ens-auth-token') : response['status'] == 'SUCCESS'
       end
 
       # private
       def message_from(action, response)
-        case action
-        when 'auth'
+        case
+        when action == 'auth'
           response['ens-auth-token']
+        when !success_from(action, response)
+          response['error']
         else
-          if !success_from(action, response)
-            response['error']
-          else
-            "#{response['status']}|#{response['type']}"
-          end
+          "#{response['status']}|#{response['type']}"
         end
       end
 
       # private
       def authorization_from(action, response)
-        case action
-        when 'auth'
-          response['ens-auth-token']
-        else
-          response['transactionId']
-        end
+        action == 'auth' ? response['ens-auth-token'] : response['transactionId']
       end
 
       # private
@@ -331,12 +319,7 @@ module ActiveMerchant #:nodoc:
       # the `auth` call wants the body to be a string and not a JSON
       # structure
       def post_data(action, parameters = {})
-        case action
-        when 'auth'
-          parameters.to_s
-        else
-          parameters.to_json
-        end
+        action == 'auth' ? parameters.to_s : parameters.to_json
       end
 
       # private

--- a/lib/active_merchant/billing/gateways/engaging_networks.rb
+++ b/lib/active_merchant/billing/gateways/engaging_networks.rb
@@ -30,24 +30,6 @@ module ActiveMerchant #:nodoc:
         jcb: 'JC'
       }
 
-      # options for this metadata should have keys in lowercase
-      # as symbols, without punctuation, for example:
-      # 'Get Involved - Membership' -> :get_involved_membership
-      METADATA_QUESTIONS =
-        [
-          'Stay Informed - Nature News',
-          'Get Involved - Advocacy',
-          'Get Involved - Events',
-          'Get Involved - Membership',
-          'Get Involved - Volunteer',
-          'Mobile Text Opt In',
-          'Mobile Call Opt In',
-          'Home Phone Opt In',
-          'F2F-How do you identify',
-          'F2F-How was your experience',
-          'Tip Jar'
-        ].map { |s| [s.gsub(/\W+/, '_').downcase.to_sym, s] }.to_h.freeze
-
       def initialize(options = {})
         requires!(options, :api_key)
         super
@@ -155,13 +137,11 @@ module ActiveMerchant #:nodoc:
 
       # private
       #
-      # `questions` is a whole set of metadata, more like a survey
-      # however all the fields are hardcoded on the CRM side, thus
-      # why we use the constant to hold them.
+      # `questions` is a whole set of metadata, more like a survey however all
+      # the fields are hardcoded on the CRM side, thus whe expect the caller to
+      # know what they are, as they are configured by the customer
       def add_questions(options)
-        options.select do |k, v|
-          METADATA_QUESTIONS.values.include?(v)
-        end.map { |k, v| [METADATA_QUESTIONS[k], v] }.to_h
+        options[:questions]&.delete_if { |_, v| v.blank? }
       end
 
       # private

--- a/lib/active_merchant/billing/gateways/engaging_networks.rb
+++ b/lib/active_merchant/billing/gateways/engaging_networks.rb
@@ -1,0 +1,346 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class EngagingNetworksGateway < Gateway
+      include Empty
+
+      self.live_url = 'https://e-activist.com'
+
+      self.supported_countries = ['US']
+      self.default_currency = 'USD'
+      self.supported_cardtypes = %i[
+        visa
+        master
+        american_express
+        discover
+        diners_club
+        jcb
+      ]
+
+      self.homepage_url = 'https://www.engagingnetworks.net/'
+      self.display_name = 'Engaging Networks'
+
+      STANDARD_ERROR_CODE_MAPPING = {}
+
+      CARD_BRAND = {
+        visa: 'VI',
+        master: 'MC',
+        american_express: 'AX',
+        discover: 'DI',
+        diners_club: 'DC',
+        jcb: 'JC'
+      }
+
+      # options for this metadata should have keys in lowercase
+      # as symbols, without punctuation, for example:
+      # 'Get Involved - Membership' -> :get_involved_membership
+      METADATA_QUESTIONS =
+        [
+          'Stay Informed - Nature News',
+          'Get Involved - Advocacy',
+          'Get Involved - Events',
+          'Get Involved - Membership',
+          'Get Involved - Volunteer',
+          'Mobile Text Opt In',
+          'Mobile Call Opt In',
+          'Home Phone Opt In',
+          'F2F-How do you identify',
+          'F2F-How was your experience',
+          'Tip Jar'
+        ].map { |s| [s.gsub(/\W+/, '_').downcase.to_sym, s] }.to_h.freeze
+
+      def initialize(options = {})
+        requires!(options, :api_key)
+        super
+      end
+
+      def purchase(amount, payment_method, options = {})
+        MultiResponse.run do |r|
+          r.process { authenticate }
+          r.process do
+            purchase_or_recurring(
+              r.authorization,
+              amount,
+              payment_method,
+              options,
+              false
+            )
+          end
+        end
+      end
+
+      def authenticate
+        post = @options[:api_key]
+        commit('auth', post)
+      end
+
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript.gsub(
+            /[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}/i,
+            '[FILTERED]'
+          ).gsub(
+            /(ens-auth-token: )([0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12})/i,
+            '\1[FILTERED]'
+          ) # the api_key is sent as the body
+          .gsub(/("ccnumber\\?":\\?")[^"\\]*/i, '\1[FILTERED]')
+          .gsub(/("ccvv\\?":\\?")\d+/, '\1[FILTERED]')
+          .gsub(/("bankaccnum\\?":\\?")\d+/, '\1[FILTERED]')
+          .gsub(/("bankrtenum\\?":\\?")\d+/, '\1[FILTERED]')
+      end
+
+      private
+
+      # private
+      #
+      # build the data structure to send to EngagingNetworks.
+      # it's important to note that this is more like a layer to
+      # a CRM and a payment gateway, we treat it like others we've
+      # implemented for customers
+      def purchase_or_recurring(
+        auth_token,
+        amount,
+        payment_method,
+        options,
+        recurring = false
+      )
+        # if processing a recurring plan, we need to ensure that
+        # we receive the frequency
+        requires!(options, :recurrfreq) if recurring
+
+        post = {}
+
+        options.merge!(ens_auth_token: auth_token)
+
+        add_customer_data(post, options)
+        add_payment_details(post, amount, payment_method, options)
+        add_metadata(post, options)
+
+        commit('sale', post, options)
+      end
+
+      # private
+      #
+      # adds the donor details
+      def add_customer_data(post, options)
+        customer = options[:customer]
+        post['supporter'] =
+          {
+            "Email Address": email(options[:email], options),
+            "First Name": customer[:first_name],
+            "Last Name": customer[:last_name],
+            "Birthday yyyy mm dd":
+              (customer[:dob] unless empty?(customer[:dob])),
+            "Mobile Phone": customer[:mobile_number],
+            "Home Phone": customer[:home_phone],
+            "questions": add_questions(options)
+          }.merge(add_address(options))
+      end
+
+      # private
+      #
+      # generates an email placeholder with the format requested by the customer
+      # if there's no donor email.
+      #
+      # Format: timestamp@fakeemail(custom_label).com
+      def email(email, options)
+        if email.blank?
+          "#{Time.now.to_i}@fakeemail#{options[:email_label]}.com"
+        else
+          email
+        end
+      end
+
+      # private
+      #
+      # `questions` is a whole set of metadata, more like a survey
+      # however all the fields are hardcoded on the CRM side, thus
+      # why we use the constant to hold them.
+      def add_questions(options)
+        options.select do |k, v|
+          METADATA_QUESTIONS.values.include?(v)
+        end.map { |k, v| [METADATA_QUESTIONS[k], v] }.to_h
+      end
+
+      # private
+      #
+      # adds the billing address of the donor, the field names are from BBCRM
+      # and so they are named in a long a free-text way
+      def add_address(options)
+        address = options[:billing_address]
+
+        post = {}
+        post['Address 1'] = address[:address1] unless empty?(address[:address1])
+        post['Address 2'] = address[:address2] unless empty?(address[:address2])
+        post['City'] = address[:city] unless empty?(address[:city])
+        post['State or Province'] = address[:state] unless empty?(
+          address[:state]
+        )
+        post['ZIP or Postal Code'] = address[:zip] unless empty?(address[:zip])
+        post['Country'] = address[:country] unless empty?(address[:country])
+
+        post
+      end
+
+      # private
+      #
+      # builds the `transaction` block that contains the payment details
+      # either CreditCard or Check (ACH). We also inform EngagingNetworks
+      # if this is a recurring transaction or not, though for the purposes
+      # of our implementation, we treat this as a one-of-transaction
+      # like we did for other CRM-that-become-gateways :(
+      def add_payment_details(post, amount, payment, options)
+        txn = {
+          "donationAmt": amount(amount),
+          "recurrpay": empty?(options[:recurrfreq]) ? 'N' : 'Y',
+          "recurrfreq": options[:recurrfreq]
+        }
+        payment_details =
+          if payment.respond_to?(:routing_number)
+            {
+              "paymenttype": 'Check',
+              "bankaccnum": payment.account_number,
+              "bankrtenum": payment.routing_number,
+              "bankacctype": payment.account_type
+            }
+          else
+            {
+              "paymenttype": CARD_BRAND[payment.brand.to_sym],
+              "ccnumber": payment.number,
+              "ccvv": payment.verification_value,
+              "ccexpire":
+                "#{format(payment.month, :two_digits)}#{format(payment.year, :two_digits)}"
+            }
+          end
+
+        post['transaction'] =
+          txn.merge(payment_details).delete_if { |_, v| v.blank? }
+      end
+
+      # private
+      #
+      # additional metadata
+      def add_metadata(post, options)
+        post['appealCode'] = options[:appealcode]
+        post['txn7'] = options[:txn7]
+      end
+
+      # private
+      def parse(body)
+        JSON.parse(body)
+      end
+
+      # private
+      def headers(options = {})
+        # during the `authenticate` call, we don't yet have the
+        # options[:ens_auth_token] set, so we remove that key if
+        # that's the case
+        {
+          :'ens-auth-token' => options[:ens_auth_token],
+          :'content-type' => 'application/json',
+          'Accept-Encoding' => 'identity'
+        }.delete_if { |k, v| v.blank? }
+      end
+
+      # private
+      #
+      # build the path to call
+      def build_uri(action, options)
+        case action
+        when 'sale'
+          "/ens/service/page/#{options[:page_id]}/process"
+        when 'auth'
+          '/ens/service/authenticate'
+        end
+      end
+
+      # private
+      def url(action, options)
+        "#{self.live_url}#{build_uri(action, options)}"
+      end
+
+      # private
+      #
+      # send it all...
+      def commit(action, parameters, options = {})
+        parameters.merge!({ "demo": true }) if test? && action != 'auth'
+        response =
+          parse(
+            ssl_post(
+              url(action, options),
+              post_data(action, parameters),
+              headers(options)
+            )
+          )
+
+        Response.new(
+          success_from(action, response),
+          message_from(action, response),
+          response,
+          authorization: authorization_from(action, response),
+          test: test?,
+          error_code: error_code_from(action, response)
+        )
+      rescue ResponseError => e
+        case e.response.code
+        when '401'
+          return Response.new(false, 'Invalid credentials', {}, test: test?)
+        end
+      end
+
+      # private
+      def success_from(action, response)
+        case action
+        when 'auth'
+          response.key?('ens-auth-token')
+        else
+          response['status'] == 'SUCCESS'
+        end
+      end
+
+      # private
+      def message_from(action, response)
+        case action
+        when 'auth'
+          response['ens-auth-token']
+        else
+          if !success_from(action, response)
+            response['error']
+          else
+            "#{response['status']}|#{response['type']}"
+          end
+        end
+      end
+
+      # private
+      def authorization_from(action, response)
+        case action
+        when 'auth'
+          response['ens-auth-token']
+        else
+          response['transactionId']
+        end
+      end
+
+      # private
+      #
+      # the `auth` call wants the body to be a string and not a JSON
+      # structure
+      def post_data(action, parameters = {})
+        case action
+        when 'auth'
+          parameters.to_s
+        else
+          parameters.to_json
+        end
+      end
+
+      # private
+      def error_code_from(action, response)
+        response['error'] unless success_from(action, response)
+      end
+    end
+  end
+end

--- a/lib/active_merchant/billing/gateways/engaging_networks.rb
+++ b/lib/active_merchant/billing/gateways/engaging_networks.rb
@@ -128,7 +128,7 @@ module ActiveMerchant #:nodoc:
         customer = options[:customer]
         post['supporter'] =
           {
-            "Email Address": email(options[:email], options),
+            "Email Address": email(options[:email], options[:email_label]),
             "First Name": customer[:first_name],
             "Last Name": customer[:last_name],
             "Birthday yyyy mm dd":
@@ -145,9 +145,9 @@ module ActiveMerchant #:nodoc:
       # if there's no donor email.
       #
       # Format: timestamp@fakeemail(custom_label).com
-      def email(email, options)
+      def email(email, email_label)
         if email.blank?
-          "#{Time.now.to_i}@fakeemail#{options[:email_label]}.com"
+          "#{Time.now.to_i}@fakeemail#{email_label]}.com"
         else
           email
         end

--- a/lib/active_merchant/billing/gateways/engaging_networks.rb
+++ b/lib/active_merchant/billing/gateways/engaging_networks.rb
@@ -128,11 +128,7 @@ module ActiveMerchant #:nodoc:
       #
       # Format: timestamp@fakeemail(custom_label).com
       def email(email, email_label)
-        if email.blank?
-          "#{Time.now.to_i}@fakeemail#{email_label}.com"
-        else
-          email
-        end
+        email.blank? ? "#{Time.now.to_i}@fakeemail#{email_label}.com" : email
       end
 
       # private
@@ -274,7 +270,11 @@ module ActiveMerchant #:nodoc:
 
       # private
       def success_from(action, response)
-        action == 'auth' ? response.key?('ens-auth-token') : response['status'] == 'SUCCESS'
+        if action == 'auth'
+          response.key?('ens-auth-token')
+        else
+          response['status'] == 'SUCCESS'
+        end
       end
 
       # private
@@ -291,7 +291,11 @@ module ActiveMerchant #:nodoc:
 
       # private
       def authorization_from(action, response)
-        action == 'auth' ? response['ens-auth-token'] : response['transactionId']
+        if action == 'auth'
+          response['ens-auth-token']
+        else
+          response['transactionId']
+        end
       end
 
       # private

--- a/lib/active_merchant/billing/gateways/engaging_networks.rb
+++ b/lib/active_merchant/billing/gateways/engaging_networks.rb
@@ -287,6 +287,8 @@ module ActiveMerchant #:nodoc:
         case e.response.code
         when '401'
           return Response.new(false, 'Invalid credentials', {}, test: test?)
+        else
+          raise
         end
       end
 

--- a/lib/active_merchant/billing/gateways/engaging_networks.rb
+++ b/lib/active_merchant/billing/gateways/engaging_networks.rb
@@ -147,7 +147,7 @@ module ActiveMerchant #:nodoc:
       # Format: timestamp@fakeemail(custom_label).com
       def email(email, email_label)
         if email.blank?
-          "#{Time.now.to_i}@fakeemail#{email_label]}.com"
+          "#{Time.now.to_i}@fakeemail#{email_label}.com"
         else
           email
         end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -294,6 +294,9 @@ element:
   application_name: "Spreedly"
   application_version: "1"
 
+engaging_networks:
+  api_key: APIKEY
+
 # login: merchant number
 # password: referrer url (for authorize authentication)
 epay:

--- a/test/remote/gateways/remote_engaging_networks_test.rb
+++ b/test/remote/gateways/remote_engaging_networks_test.rb
@@ -1,0 +1,120 @@
+require 'test_helper'
+
+class RemoteEngagingNetworksTest < Test::Unit::TestCase
+  def setup
+    @gateway = EngagingNetworksGateway.new(fixtures(:engaging_networks))
+
+    @amount = 100
+    @credit_card = credit_card('4000100011112224')
+
+    # Use the same approach as WorldPay, as EngagingNetworks uses Vantiv
+    # under the hood
+    @declined_card =
+      credit_card('4111111111111111', first_name: nil, last_name: 'REFUSED')
+    @check = check(account_type: 'checking')
+    @options = {
+      billing_address:
+        address(city: 'Hollywood', state: 'CA', zip: '90210', country: 'US'),
+      description: 'Evergiving Donation',
+      email_label: 'EVG',
+      customer: {
+        dob: '1981-01-01',
+        first_name: 'Longbob',
+        last_name: 'Longsen',
+        mobile_number: address[:phone],
+        home_home: address[:phone]
+      },
+      page_id: 78_936,
+      appealcode: 'BBCRMSOURCECODE',
+      txn7: "[EVG][123][#{SecureRandom.hex(15)}]"
+    }
+  end
+
+  def test_successful_authenticate
+    response = @gateway.authenticate
+    assert_success response
+    assert_match /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+                 response.message
+  end
+
+  def test_failed_login
+    gateway = EngagingNetworksGateway.new(api_key: 'foobar')
+    response = gateway.authenticate
+    assert_failure response
+    assert_equal 'Invalid credentials', response.message
+  end
+
+  def test_successful_donation
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'SUCCESS|CREDIT_SINGLE', response.message
+  end
+
+  def test_successful_donation_with_more_options
+    options = {
+      billing_address:
+        address(city: 'Hollywood', state: 'CA', zip: '90210', country: 'US'),
+      description: 'Evergiving Donation',
+      email: 'test@example.com',
+      customer: {
+        dob: '1981-01-01',
+        first_name: 'Longbob',
+        last_name: 'Longsen',
+        mobile_number: address[:phone],
+        home_home: address[:phone]
+      },
+      stay_informed_nature_news: 'Y',
+      get_involved_advocacy: 'Y',
+      get_involved_membership: 'Y',
+      get_involved_events: 'Y',
+      get_involved_volunteer: 'Y',
+      page_id: 78_936,
+      appealcode: 'BBCRMSOURCECODE',
+      txn7: "[EVG][123][#{SecureRandom.hex(15)}]"
+    }
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_equal 'SUCCESS|CREDIT_SINGLE', response.message
+  end
+
+  def test_successful_recurring_donation
+    @options.merge!(recurrfreq: 'QUARTERLY')
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'SUCCESS|CREDIT_RECURRING', response.message
+  end
+
+  def test_successful_ach_donation
+    response = @gateway.purchase(@amount, @check, @options)
+    assert_success response
+    assert_equal 'SUCCESS|CHECK', response.message
+  end
+
+  def test_successful_ach_recurring_donation
+    @options.merge!(recurrfreq: 'QUARTERLY')
+
+    response = @gateway.purchase(@amount, @check, @options)
+    assert_success response
+    assert_equal 'SUCCESS|RECUR_UNMANAGED', response.message
+  end
+
+  def test_failed_purchase
+    @options[:customer][:first_name] = @declined_card.first_name
+    @options[:customer][:last_name] = @declined_card.last_name
+    response = @gateway.purchase(@amount, @declined_card, @options)
+    assert_failure response
+    assert_equal 'First Name is required for the Vantiv Gateway but was not passed in.',
+                 response.message
+  end
+
+  def test_transcript_scrubbing
+    transcript =
+      capture_transcript(@gateway) do
+        @gateway.purchase(@amount, @credit_card, @options)
+      end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card.number, transcript)
+    assert_scrubbed(@gateway.options[:api_key], transcript)
+  end
+end

--- a/test/remote/gateways/remote_engaging_networks_test.rb
+++ b/test/remote/gateways/remote_engaging_networks_test.rb
@@ -63,11 +63,13 @@ class RemoteEngagingNetworksTest < Test::Unit::TestCase
         mobile_number: address[:phone],
         home_home: address[:phone]
       },
-      stay_informed_nature_news: 'Y',
-      get_involved_advocacy: 'Y',
-      get_involved_membership: 'Y',
-      get_involved_events: 'Y',
-      get_involved_volunteer: 'Y',
+      questions: {
+        'Stay Informed - Nature News': 'Y',
+        'Get Involved - Advocacy': 'Y',
+        'Get Involved - Events': 'Y',
+        'Get Involved - Membership': 'Y',
+        'Get Involved - Volunteer': 'Y'
+      },
       page_id: 78_936,
       appealcode: 'BBCRMSOURCECODE',
       txn7: "[EVG][123][#{SecureRandom.hex(15)}]"

--- a/test/unit/gateways/engaging_networks_test.rb
+++ b/test/unit/gateways/engaging_networks_test.rb
@@ -1,0 +1,277 @@
+require 'test_helper'
+
+class EngagingNetworksTest < Test::Unit::TestCase
+  include CommStub
+
+  def setup
+    @gateway = EngagingNetworksGateway.new(api_key: 'foo')
+    @credit_card = credit_card
+    @amount = 100
+
+    @options = {
+      billing_address:
+        address(city: 'Hollywood', state: 'CA', zip: '90210', country: 'US'),
+      description: 'Evergiving Donation',
+      email_label: 'EVG',
+      customer: {
+        dob: '1981-01-01',
+        first_name: 'Longbob',
+        last_name: 'Longsen',
+        mobile_number: address[:phone],
+        home_home: address[:phone]
+      },
+      page_id: 78_936,
+      appealcode: 'BBCRMSOURCECODE',
+      txn7: '[EVG][123][d63bbc3ace2d9df93013027510e66e]'
+    }
+  end
+
+  def test_successful_purchase
+    response =
+      stub_comms do
+        @gateway.purchase(@amount, @credit_card, @options)
+      end.respond_with(
+        successful_authenticate_response,
+        successful_donation_response
+      )
+
+    assert_success response
+
+    assert_equal '84074488135026237__2951266454422224__619253793273803',
+                 response.authorization
+    assert response.test?
+  end
+
+  def test_failed_purchase
+    response =
+      stub_comms do
+        @gateway.purchase(@amount, @credit_card, @options)
+      end.respond_with(
+        successful_authenticate_response,
+        failed_donation_response
+      )
+
+    assert_failure response
+    assert_equal 'First Name is required for the Vantiv Gateway but was not passed in.',
+                 response.message
+  end
+
+  def test_failed_authentication
+    response_401 =
+      stub(code: '401', message: 'Unauthorized', body: failed_login_response)
+    @gateway
+      .expects(:ssl_post)
+      .raises(ActiveMerchant::ResponseError.new(response_401))
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal 'Invalid credentials', response.message
+  end
+
+  def test_scrub_card
+    assert @gateway.supports_scrubbing?
+    assert_equal @gateway.scrub(pre_scrubbed_card), post_scrubbed_card
+  end
+
+  def test_scrub_check
+    assert @gateway.supports_scrubbing?
+    assert_equal @gateway.scrub(pre_scrubbed_check), post_scrubbed_check
+  end
+
+  private
+
+  def successful_authenticate_response
+    '{"ens-auth-token":"307bb09d-8d05-4d5c-95bd-cf592dc37cf2","expires":3600000}'
+  end
+
+  def successful_donation_response
+    '{"amount":1.0,"paymentType":"TEST: VI","recurringPayment":false,"createdOn":1621994124999,"error":"","supporterId":216617813,"supporterEmailAddress":"1621994123@fakeemailevg.com","transactionId":"84074488135026237__2951266454422224__619253793273803","currency":"USD","status":"SUCCESS","id":24010094,"type":"CREDIT_SINGLE"}'
+  end
+
+  def failed_donation_response
+    '{"error":"First Name is required for the Vantiv Gateway but was not passed in.","supporterId":216617991,"supporterEmailAddress":"1621994677@fakeemailevg.com","status":"ERROR","id":1272014647}'
+  end
+
+  def pre_scrubbed_card
+    %q(
+      opening connection to e-activist.com:443...
+      opened
+      starting SSL for e-activist.com:443...
+      SSL established, protocol: TLSv1.2, cipher: ECDHE-RSA-AES256-GCM-SHA384
+      <- "POST /ens/service/authenticate HTTP/1.1\r\nContent-Type: application/json\r\nAccept-Encoding: identity\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: e-activist.com\r\nContent-Length: 36\r\n\r\n"
+      <- "df33591e-5900-4804-a304-3a3c97553ff7"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Content-Encoding: identity\r\n"
+      -> "Connection: close\r\n"
+      -> "X-Powered-By: Undertow/1\r\n"
+      -> "Server: WildFly/10\r\n"
+      -> "Content-Type: application/json\r\n"
+      -> "Date: Mon, 24 May 2021 06:21:47 GMT\r\n"
+      -> "\r\n"
+      reading all...
+      -> "{\"expires\":3600000,\"ens-auth-token\":\"56b0b4a9-851e-4857-b50b-d4386ee80075\"}"
+      read 75 bytes
+      Conn close
+      opening connection to e-activist.com:443...
+      opened
+      starting SSL for e-activist.com:443...
+      SSL established, protocol: TLSv1.2, cipher: ECDHE-RSA-AES256-GCM-SHA384
+      <- "POST /ens/service/page/12345/process HTTP/1.1\r\nContent-Type: application/json\r\nEns-Auth-Token: 56b0b4a9-851e-4857-b50b-d4386ee80075\r\nAccept-Encoding: identity\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: e-activist.com\r\nContent-Length: 558\r\n\r\n"
+      <- "{\"supporter\":{\"Email Address\":\"test@example.com\",\"First Name\":\"Longbob\",\"Last Name\":\"Longsen\",\"Birthday yyyy mm dd\":\"1981-01-01\",\"Mobile Phone\":\"(555)555-5555\",\"Home Phone\":null,\"questions\":{},\"Address 1\":\"456 My Street\",\"Address 2\":\"Apt 1\",\"City\":\"Hollywood\",\"State or Province\":\"CA\",\"ZIP or Postal Code\":\"90210\",\"Country\":\"US\"},\"transaction\":{\"paymenttype\":\"VI\",\"donationAmt\":\"1.00\",\"ccnumber\":\"4000100011112224\",\"ccvv\":\"123\",\"ccexpire\":\"0922\",\"recurrpay\":\"N\"},\"appealCode\":\"BBCRMSOURCECODE\",\"txn7\":\"[EVG][123][8133299d68a8de5ea3125ab10e820b]\",\"demo\":true}"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Content-Encoding: identity\r\n"
+      -> "X-Powered-By: Undertow/1\r\n"
+      -> "Access-Control-Allow-Headers: Origin, Content-Type, Accept, Authorization, X-Requested-With, ens-auth-token, ens-client-id\r\n"
+      -> "Server: WildFly/10\r\n"
+      -> "Date: Mon, 24 May 2021 06:21:50 GMT\r\n"
+      -> "Connection: close\r\n"
+      -> "Access-Control-Allow-Origin: *\r\n"
+      -> "Access-Control-Allow-Credentials: true\r\n"
+      -> "Content-Type: application/json\r\n"
+      -> "Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS, HEAD\r\n"
+      -> "\r\n"
+      reading all...
+      -> "{\"createdOn\":1621837310112,\"amount\":1.0,\"paymentType\":\"TEST: VI\",\"recurringPayment\":false,\"error\":\"\",\"transactionId\":\"84074475292837191__2951266454422224__362090122111489\",\"supporterEmailAddress\":\"test@example.com\",\"supporterId\":216282715,\"id\":23995860,\"type\":\"CREDIT_SINGLE\",\"currency\":\"USD\",\"status\":\"SUCCESS\"}"
+      read 312 bytes
+      Conn close
+    )
+  end
+
+  def post_scrubbed_card
+    %q(
+      opening connection to e-activist.com:443...
+      opened
+      starting SSL for e-activist.com:443...
+      SSL established, protocol: TLSv1.2, cipher: ECDHE-RSA-AES256-GCM-SHA384
+      <- "POST /ens/service/authenticate HTTP/1.1\r\nContent-Type: application/json\r\nAccept-Encoding: identity\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: e-activist.com\r\nContent-Length: 36\r\n\r\n"
+      <- "[FILTERED]"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Content-Encoding: identity\r\n"
+      -> "Connection: close\r\n"
+      -> "X-Powered-By: Undertow/1\r\n"
+      -> "Server: WildFly/10\r\n"
+      -> "Content-Type: application/json\r\n"
+      -> "Date: Mon, 24 May 2021 06:21:47 GMT\r\n"
+      -> "\r\n"
+      reading all...
+      -> "{\"expires\":3600000,\"ens-auth-token\":\"[FILTERED]\"}"
+      read 75 bytes
+      Conn close
+      opening connection to e-activist.com:443...
+      opened
+      starting SSL for e-activist.com:443...
+      SSL established, protocol: TLSv1.2, cipher: ECDHE-RSA-AES256-GCM-SHA384
+      <- "POST /ens/service/page/12345/process HTTP/1.1\r\nContent-Type: application/json\r\nEns-Auth-Token: [FILTERED]\r\nAccept-Encoding: identity\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: e-activist.com\r\nContent-Length: 558\r\n\r\n"
+      <- "{\"supporter\":{\"Email Address\":\"test@example.com\",\"First Name\":\"Longbob\",\"Last Name\":\"Longsen\",\"Birthday yyyy mm dd\":\"1981-01-01\",\"Mobile Phone\":\"(555)555-5555\",\"Home Phone\":null,\"questions\":{},\"Address 1\":\"456 My Street\",\"Address 2\":\"Apt 1\",\"City\":\"Hollywood\",\"State or Province\":\"CA\",\"ZIP or Postal Code\":\"90210\",\"Country\":\"US\"},\"transaction\":{\"paymenttype\":\"VI\",\"donationAmt\":\"1.00\",\"ccnumber\":\"[FILTERED]\",\"ccvv\":\"[FILTERED]\",\"ccexpire\":\"0922\",\"recurrpay\":\"N\"},\"appealCode\":\"BBCRMSOURCECODE\",\"txn7\":\"[EVG][123][8133299d68a8de5ea3125ab10e820b]\",\"demo\":true}"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Content-Encoding: identity\r\n"
+      -> "X-Powered-By: Undertow/1\r\n"
+      -> "Access-Control-Allow-Headers: Origin, Content-Type, Accept, Authorization, X-Requested-With, ens-auth-token, ens-client-id\r\n"
+      -> "Server: WildFly/10\r\n"
+      -> "Date: Mon, 24 May 2021 06:21:50 GMT\r\n"
+      -> "Connection: close\r\n"
+      -> "Access-Control-Allow-Origin: *\r\n"
+      -> "Access-Control-Allow-Credentials: true\r\n"
+      -> "Content-Type: application/json\r\n"
+      -> "Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS, HEAD\r\n"
+      -> "\r\n"
+      reading all...
+      -> "{\"createdOn\":1621837310112,\"amount\":1.0,\"paymentType\":\"TEST: VI\",\"recurringPayment\":false,\"error\":\"\",\"transactionId\":\"84074475292837191__2951266454422224__362090122111489\",\"supporterEmailAddress\":\"test@example.com\",\"supporterId\":216282715,\"id\":23995860,\"type\":\"CREDIT_SINGLE\",\"currency\":\"USD\",\"status\":\"SUCCESS\"}"
+      read 312 bytes
+      Conn close
+    )
+  end
+
+  def pre_scrubbed_check
+    %q(
+      opening connection to e-activist.com:443...
+      opened
+      starting SSL for e-activist.com:443...
+      SSL established, protocol: TLSv1.2, cipher: ECDHE-RSA-AES256-GCM-SHA384
+      <- "POST /ens/service/authenticate HTTP/1.1\r\nContent-Type: application/json\r\nAccept-Encoding: identity\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: e-activist.com\r\nContent-Length: 36\r\n\r\n"
+      <- "df33591e-5900-4804-a304-3a3c97553ff7"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Content-Encoding: identity\r\n"
+      -> "Connection: close\r\n"
+      -> "X-Powered-By: Undertow/1\r\n"
+      -> "Server: WildFly/10\r\n"
+      -> "Content-Type: application/json\r\n"
+      -> "Date: Wed, 26 May 2021 01:46:09 GMT\r\n"
+      -> "\r\n"
+      reading all...
+      -> "{\"expires\":3600000,\"ens-auth-token\":\"56b0b4a9-851e-4857-b50b-d4386ee80075\"}"
+      read 75 bytes
+      Conn close
+      opening connection to e-activist.com:443...
+      opened
+      starting SSL for e-activist.com:443...
+      SSL established, protocol: TLSv1.2, cipher: ECDHE-RSA-AES256-GCM-SHA384
+      <- "POST /ens/service/page/12345/process HTTP/1.1\r\nContent-Type: application/json\r\nEns-Auth-Token: 56b0b4a9-851e-4857-b50b-d4386ee80075\r\nAccept-Encoding: identity\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: e-activist.com\r\nContent-Length: 558\r\n\r\n"
+      <- "{\"supporter\":{\"Email Address\":\"test@example.com\",\"First Name\":\"Longbob\",\"Last Name\":\"Longsen\",\"Birthday yyyy mm dd\":\"1981-01-01\",\"Mobile Phone\":\"(555)555-5555\",\"Home Phone\":null,\"questions\":{},\"Address 1\":\"456 My Street\",\"Address 2\":\"Apt 1\",\"City\":\"Hollywood\",\"State or Province\":\"CA\",\"ZIP or Postal Code\":\"90210\",\"Country\":\"US\"},\"transaction\":{\"donationAmt\":\"1.00\",\"recurrpay\":\"N\",\"paymenttype\":\"Check\",\"bankaccnum\":\"15378535\",\"bankrtenum\":\"244183602\",\"bankacctype\":\"checking\"},\"appealCode\":\"BBCRMSOURCECODE\",\"txn7\":\"[EVG][123][82dbf5a28dac4fac1e29b535456010]\",\"demo\":true}"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Content-Encoding: identity\r\n"
+      -> "X-Powered-By: Undertow/1\r\n"
+      -> "Access-Control-Allow-Headers: Origin, Content-Type, Accept, Authorization, X-Requested-With, ens-auth-token, ens-client-id\r\n"
+      -> "Server: WildFly/10\r\n"
+      -> "Date: Wed, 26 May 2021 01:46:09 GMT\r\n"
+      -> "Connection: close\r\n"
+      -> "Access-Control-Allow-Origin: *\r\n"
+      -> "Access-Control-Allow-Credentials: true\r\n"
+      -> "Content-Type: application/json\r\n"
+      -> "Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS, HEAD\r\n"
+      -> "\r\n"
+      reading all...
+      -> "{\"amount\":1.0,\"paymentType\":\"TEST: Check\",\"recurringPayment\":false,\"createdOn\":1621993570723,\"error\":\"\",\"supporterId\":216617656,\"supporterEmailAddress\":\"1621993569@fakeemailevg.com\",\"transactionId\":\"ND216617656T8937111153482478592\",\"currency\":\"USD\",\"status\":\"SUCCESS\",\"id\":24010064,\"type\":\"CHECK\"}"
+      read 312 bytes
+      Conn close
+    )
+  end
+
+  def post_scrubbed_check
+    %q(
+      opening connection to e-activist.com:443...
+      opened
+      starting SSL for e-activist.com:443...
+      SSL established, protocol: TLSv1.2, cipher: ECDHE-RSA-AES256-GCM-SHA384
+      <- "POST /ens/service/authenticate HTTP/1.1\r\nContent-Type: application/json\r\nAccept-Encoding: identity\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: e-activist.com\r\nContent-Length: 36\r\n\r\n"
+      <- "[FILTERED]"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Content-Encoding: identity\r\n"
+      -> "Connection: close\r\n"
+      -> "X-Powered-By: Undertow/1\r\n"
+      -> "Server: WildFly/10\r\n"
+      -> "Content-Type: application/json\r\n"
+      -> "Date: Wed, 26 May 2021 01:46:09 GMT\r\n"
+      -> "\r\n"
+      reading all...
+      -> "{\"expires\":3600000,\"ens-auth-token\":\"[FILTERED]\"}"
+      read 75 bytes
+      Conn close
+      opening connection to e-activist.com:443...
+      opened
+      starting SSL for e-activist.com:443...
+      SSL established, protocol: TLSv1.2, cipher: ECDHE-RSA-AES256-GCM-SHA384
+      <- "POST /ens/service/page/12345/process HTTP/1.1\r\nContent-Type: application/json\r\nEns-Auth-Token: [FILTERED]\r\nAccept-Encoding: identity\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: e-activist.com\r\nContent-Length: 558\r\n\r\n"
+      <- "{\"supporter\":{\"Email Address\":\"test@example.com\",\"First Name\":\"Longbob\",\"Last Name\":\"Longsen\",\"Birthday yyyy mm dd\":\"1981-01-01\",\"Mobile Phone\":\"(555)555-5555\",\"Home Phone\":null,\"questions\":{},\"Address 1\":\"456 My Street\",\"Address 2\":\"Apt 1\",\"City\":\"Hollywood\",\"State or Province\":\"CA\",\"ZIP or Postal Code\":\"90210\",\"Country\":\"US\"},\"transaction\":{\"donationAmt\":\"1.00\",\"recurrpay\":\"N\",\"paymenttype\":\"Check\",\"bankaccnum\":\"[FILTERED]\",\"bankrtenum\":\"[FILTERED]\",\"bankacctype\":\"checking\"},\"appealCode\":\"BBCRMSOURCECODE\",\"txn7\":\"[EVG][123][82dbf5a28dac4fac1e29b535456010]\",\"demo\":true}"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Content-Encoding: identity\r\n"
+      -> "X-Powered-By: Undertow/1\r\n"
+      -> "Access-Control-Allow-Headers: Origin, Content-Type, Accept, Authorization, X-Requested-With, ens-auth-token, ens-client-id\r\n"
+      -> "Server: WildFly/10\r\n"
+      -> "Date: Wed, 26 May 2021 01:46:09 GMT\r\n"
+      -> "Connection: close\r\n"
+      -> "Access-Control-Allow-Origin: *\r\n"
+      -> "Access-Control-Allow-Credentials: true\r\n"
+      -> "Content-Type: application/json\r\n"
+      -> "Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS, HEAD\r\n"
+      -> "\r\n"
+      reading all...
+      -> "{\"amount\":1.0,\"paymentType\":\"TEST: Check\",\"recurringPayment\":false,\"createdOn\":1621993570723,\"error\":\"\",\"supporterId\":216617656,\"supporterEmailAddress\":\"1621993569@fakeemailevg.com\",\"transactionId\":\"ND216617656T8937111153482478592\",\"currency\":\"USD\",\"status\":\"SUCCESS\",\"id\":24010064,\"type\":\"CHECK\"}"
+      read 312 bytes
+      Conn close
+    )
+  end
+
+  def failed_login_response
+    '{"messageId":10000000,"message":"Invalid api key [foobar]"}'
+  end
+end


### PR DESCRIPTION
This is like JacksonRiver and other CRM/PaymentGateway concentrators. It's not technically a gateway, as it uses Vantiv/Worldpay in the background, combined with BBCRM.

The gateway supports creditcard and directdebit `purchase`, however given the comment above, you will see that the implementation contains support for recurring billing for each payment method, however those are handled by EN and not sent/expected differently. I've implemented this to match the approach we took with Convio, i.e. we expose only one method and the CRM does all the decision based on the data we pass.

EN supplies an `api_key` that we pass on to retrieve a session token during the authentication call, we then use that token in the headers of our subsequent interaction.

```Shell
$ docker run -it --rm -v "$PWD":/app waysact/active_merchant ruby -Itest test/unit/gateways/engaging_networks_test.rb
Loaded suite test/unit/gateways/engaging_networks_test
Started
.....
Finished in 0.031073083 seconds.
-----------------------------------------------------------------------------------------------------
5 tests, 19 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-----------------------------------------------------------------------------------------------------
160.91 tests/s, 611.46 assertions/s
```

```Shell
$ docker run -it --rm -v "$PWD":/app waysact/active_merchant ruby -Itest test/remote/gateways/remote_engaging_networks_test.rb
Loaded suite test/remote/gateways/remote_engaging_networks_test
Started
.........
Finished in 18.350281955 seconds.
-----------------------------------------------------------------------------------------------------
9 tests, 18 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-----------------------------------------------------------------------------------------------------
```

Refs waysact/evergiving#6789