### PR TITLE
Add new fields to Engaging Networks

### DIFF
--- a/lib/active_merchant/billing/gateways/engaging_networks.rb
+++ b/lib/active_merchant/billing/gateways/engaging_networks.rb
@@ -171,7 +171,8 @@ module ActiveMerchant #:nodoc:
         txn = {
           "donationAmt": amount(amount),
           "recurrpay": empty?(options[:recurrfreq]) ? 'N' : 'Y',
-          "recurrfreq": options[:recurrfreq]
+          "recurrfreq": options[:recurrfreq],
+          "othamt4": options[:othamt4]
         }
         payment_details =
           if payment.respond_to?(:routing_number)
@@ -191,6 +192,11 @@ module ActiveMerchant #:nodoc:
             }
           end
 
+        # if we are processing a creditcard payment, we need to insert
+        # the cardholder name in the supporter hash
+        unless payment.respond_to?(:routing_number)
+          post['supporter'].merge!("Credit Card Holder Name": payment.name)
+        end
         post['transaction'] =
           txn.merge(payment_details).delete_if { |_, v| v.blank? }
       end
@@ -201,6 +207,7 @@ module ActiveMerchant #:nodoc:
       def add_metadata(post, options)
         post['appealCode'] = options[:appealcode]
         post['txn7'] = options[:txn7]
+        post['txn8'] = options[:txn8] unless empty?(options[:txn8])
       end
 
       # private

--- a/test/remote/gateways/remote_engaging_networks_test.rb
+++ b/test/remote/gateways/remote_engaging_networks_test.rb
@@ -72,7 +72,9 @@ class RemoteEngagingNetworksTest < Test::Unit::TestCase
       },
       page_id: 78_936,
       appealcode: 'BBCRMSOURCECODE',
-      txn7: "[EVG][123][#{SecureRandom.hex(15)}]"
+      txn7: "[EVG][123][#{SecureRandom.hex(15)}]",
+      txn8: "FOO-BAR-ZZZZ",
+      othamt4: "Unrestricted"
     }
     response = @gateway.purchase(@amount, @credit_card, options)
     assert_success response


### PR DESCRIPTION
Adding a couple of new fields that are required by our customers using EN, namely we pass an `othamt4` in the `transaction` block, an additional metadata field `txn8` and if it's a creditcard payment, we also send the `creditcard holdername` in the `customer` block.

Refs waysact/evergiving#6991

```
❯ docker run -e DEBUG_ACTIVE_MERCHANT=true -it --rm -v "$PWD":/app waysact/active_merchant ruby -Itest test/unit/gateways/engaging_networks_test.rb
Loaded suite test/unit/gateways/engaging_networks_test
Started
.....
Finished in 0.008341244 seconds.
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
5 tests, 19 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
599.43 tests/s, 2277.84 assertions/s
```

```
❯ docker run -it --rm -v "$PWD":/app waysact/active_merchant ruby -Itest test/remote/gateways/remote_engaging_networks_test.rb
Loaded suite test/remote/gateways/remote_engaging_networks_test
Started
.........
Finished in 19.206400742 seconds.
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
9 tests, 18 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
0.47 tests/s, 0.94 assertions/s
```